### PR TITLE
flatten/flatten_view/ref

### DIFF
--- a/doc/algorithm.qbk
+++ b/doc/algorithm.qbk
@@ -1841,6 +1841,50 @@ Constant. Returns a view which is lazily evaluated.
 
 [endsect]
 
+[section flatten]
+
+[heading Description]
+Returns a new sequence without nested sequences.
+
+[heading Synopsis]
+    template<
+        typename Sequence
+        >
+    typename __result_of_flatten__<Sequence>::type flatten(Sequence& seq);
+    
+    template<
+        typename Sequence
+        >
+    typename __result_of_flatten__<Sequence const>::type flatten(Sequence const& seq);
+
+[table Parameters
+    [[Parameter][Requirement][Description]]
+    [[`seq`][A model of __forward_sequence__][Operation's argument]]
+]
+
+[heading Expression Semantics]
+    __flatten__(seq);
+
+[*Return type]:
+
+* A model of __forward_sequence__.
+
+[*Semantics]: Returns a new sequence containing all the leaf elements of `seq`.
+
+[heading Complexity]
+Constant. Returns a view which is lazily evaluated.
+
+[heading Header]
+
+    #include <boost/fusion/algorithm/transformation/flatten.hpp>
+    #include <boost/fusion/include/flatten.hpp>
+
+[heading Example]
+    const __vector__<int, int, __vector__<int, int>, int> vec(1, 2, __make_vector__(3, 4), 5);
+    assert(__flatten__(vec) == __make_vector__(1, 2, 3, 4, 5)));
+
+[endsect]
+
 [endsect]
 
 [section Metafunctions]
@@ -2630,6 +2674,44 @@ Constant.
 
     #include <boost/fusion/algorithm/transformation/push_front.hpp>
     #include <boost/fusion/include/push_front.hpp>
+
+[endsect]
+
+[section flatten]
+
+[heading Description]
+Returns the result type of __flatten__, given the input sequence type.
+
+[heading Synopsis]
+    template<
+        typename Sequence
+        >
+    struct flatten
+    {
+        typedef __unspecified__ type;
+    };
+
+[table Parameters
+    [[Parameter][Requirement][Description]]
+    [[`Sequence`][A model of __forward_sequence__][Operation's argument]]
+]
+
+[heading Expression Semantics]
+    __result_of_flatten__<Sequence>::type
+
+[*Return type]:
+
+* A model of __forward_sequence__.
+
+[*Semantics]: Returns a sequence with all the leaf elements of `Sequence`.
+
+[heading Complexity]
+Constant.
+
+[heading Header]
+
+    #include <boost/fusion/algorithm/transformation/flatten.hpp>
+    #include <boost/fusion/include/flatten.hpp>
 
 [endsect]
 

--- a/doc/fusion.qbk
+++ b/doc/fusion.qbk
@@ -30,7 +30,7 @@
 [def __mpl__                    [@http://www.boost.org/libs/mpl/index.html MPL]]
 [def __stl__                    [@http://en.wikipedia.org/wiki/Standard_Template_Library STL]]
 [def __tuple__                  [@http://www.boost.org/libs/tuple/doc/tuple_users_guide.html Boost.Tuple]]
-[def __tr1__tuple__             [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2002/n1403.pdf TR1 Tuple]]
+[def __tr1__tuple__             [@http://std.dkuug.dk/jtc1/sc22/wg21/docs/papers/2002/n1403.pdf TR1 Tuple]]
 [def __boost_tools__            [@http://www.boost.org/tools/index.html Boost Tools]]
 [def __spirit_list__            [@https://lists.sourceforge.net/lists/listinfo/spirit-general Spirit Mailing List]]
 [def __spirit_general__         [@news://news.gmane.org/gmane.comp.spirit.general Spirit General NNTP news portal]]
@@ -131,6 +131,7 @@
 [def __transform_view__         [link fusion.view.transform_view `transform_view`]]
 [def __reverse_view__           [link fusion.view.reverse_view `reverse_view`]]
 [def __zip_view__               [link fusion.view.zip_view `zip_view`]]
+[def __flatten_view__           [link fusion.view.flatten_view `flatten_view`]]
 
 [def __array__                  [link fusion.adapted.array array]]
 [def __std_pair__               [link fusion.adapted.std__pair `std::pair`]]
@@ -288,6 +289,8 @@
 [def __result_of_push_back__    [link fusion.algorithm.transformation.metafunctions.push_back `result_of::push_back`]]
 [def __push_front__             [link fusion.algorithm.transformation.functions.push_front `push_front`]]
 [def __result_of_push_front__   [link fusion.algorithm.transformation.metafunctions.push_front `result_of::push_front`]]
+[def __flatten__                [link fusion.algorithm.transformation.functions.flatten `flatten`]]
+[def __result_of_flatten__      [link fusion.algorithm.transformation.metafunctions.flatten `result_of::flatten`]]
 
 [def __tr1_tuple_pair__         [link fusion.tuple.pairs `TR1 and std::pair`]]
 [def __tuple_get__              [link fusion.tuple.class_template_tuple.element_access `get`]]

--- a/doc/view.qbk
+++ b/doc/view.qbk
@@ -549,7 +549,6 @@ of the original Fusion __sequence__
 
 [endsect]
 
-
 [section repetitive_view]
 
 [heading Description]
@@ -612,6 +611,60 @@ printing a `repetitive_view` to `std::cout` is not.
     vec2 v2(repetitive_view<vec1>(v1));
 
     std::cout << v2 << std::endl; // 1, 'c', 2.0, 1, 'c'
+
+[endsect]
+
+[section flatten_view]
+
+[heading Description]
+
+`flatten_view` presents a view which iterates over its elements recursively in depth-first order.
+
+[heading Header]
+
+    #include <boost/fusion/view/flatten_view.hpp>
+    #include <boost/fusion/include/flatten_view.hpp>
+
+[heading Synopsis]
+
+    template <typename Sequence>
+    struct flatten_view;
+
+[heading Template parameters]
+
+[table
+    [[Parameter]            [Description]                   [Default]]
+    [[`Sequence`]           [A __forward_sequence__]        []]
+]
+
+[heading Model of]
+
+* __forward_sequence__
+
+[variablelist Notation
+    [[`F`]             [A `flatten_view` type]]
+    [[`s`]             [An instance of `Sequence`]]
+    [[`f`, `f2`]       [Instances of `F`]]
+]
+
+[heading Expression Semantics]
+
+Semantics of an expression is defined only where it differs from, or is not
+defined in __forward_sequence__.
+
+[table
+    [[Expression]           [Semantics]]
+    [[`F(s)`]              	[Creates a `flatten_view` given sequence, `s`.]]
+    [[`F(f)`]             	[Copy constructs a `flatten_view` from another `flatten_view`, `f`.]]
+    [[`f = f2`]           	[Assigns to a `flatten_view`, `f`, from another `flatten_view`, `f2`.]]
+]
+
+[heading Example]
+    typedef __vector__<int, int, __vector__<int, int>, int> sequence_type;
+    sequence_type seq;
+    __flatten_view__<sequence_type> flattened(seq);
+    __copy__(__make_vector__(1, 2, 3, 4, 5), flattened);
+    assert(seq == __make_vector__(1, 2, __make_vector__(3, 4), 5));
 
 [endsect]
 

--- a/include/boost/fusion/algorithm/transformation.hpp
+++ b/include/boost/fusion/algorithm/transformation.hpp
@@ -26,6 +26,7 @@
 #include <boost/fusion/algorithm/transformation/replace_if.hpp>
 #include <boost/fusion/algorithm/transformation/reverse.hpp>
 #include <boost/fusion/algorithm/transformation/transform.hpp>
-#include <boost/fusion/algorithm/transformation/zip.hpp> 
+#include <boost/fusion/algorithm/transformation/zip.hpp>
+#include <boost/fusion/algorithm/transformation/flatten.hpp>
 
 #endif

--- a/include/boost/fusion/algorithm/transformation/flatten.hpp
+++ b/include/boost/fusion/algorithm/transformation/flatten.hpp
@@ -1,0 +1,44 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef BOOST_FUSION_ALGORITHM_FLATTEN_HPP_INCLUDED
+#define BOOST_FUSION_ALGORITHM_FLATTEN_HPP_INCLUDED
+
+
+#include <boost/fusion/view/flatten_view.hpp>
+#include <boost/fusion/support/is_sequence.hpp>
+#include <boost/utility/enable_if.hpp>
+
+
+namespace boost { namespace fusion { namespace result_of
+{
+    template<typename Sequence>
+    struct flatten
+    {
+        typedef flatten_view<Sequence> type;
+    };
+}}}
+
+namespace boost { namespace fusion
+{
+    template <typename Sequence>
+    inline typename result_of::flatten<Sequence>::type
+    flatten(Sequence& view)
+    {
+        return flatten_view<Sequence>(view);
+    }
+    
+    template <typename Sequence>
+    inline typename result_of::flatten<Sequence const>::type
+    flatten(Sequence const& view)
+    {
+        return flatten_view<Sequence const>(view);
+    }
+}}
+
+
+#endif
+

--- a/include/boost/fusion/include/flatten.hpp
+++ b/include/boost/fusion/include/flatten.hpp
@@ -1,0 +1,14 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2014 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef FUSION_INCLUDE_FLATTEN
+#define FUSION_INCLUDE_FLATTEN
+
+
+#include <boost/fusion/algorithm/transformation/flatten.hpp>
+
+
+#endif

--- a/include/boost/fusion/include/flatten_view.hpp
+++ b/include/boost/fusion/include/flatten_view.hpp
@@ -1,0 +1,14 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2014 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef FUSION_INCLUDE_FLATTEN_VIEW
+#define FUSION_INCLUDE_FLATTEN_VIEW
+
+
+#include <boost/fusion/view/flatten_view.hpp>
+
+
+#endif

--- a/include/boost/fusion/include/ref.hpp
+++ b/include/boost/fusion/include/ref.hpp
@@ -1,0 +1,14 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2014 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef FUSION_INCLUDE_REF
+#define FUSION_INCLUDE_REF
+
+
+#include <boost/fusion/support/ref.hpp>
+
+
+#endif

--- a/include/boost/fusion/support.hpp
+++ b/include/boost/fusion/support.hpp
@@ -21,5 +21,6 @@
 #include <boost/fusion/support/deduce_sequence.hpp>
 #include <boost/fusion/support/unused.hpp>
 #include <boost/fusion/support/as_const.hpp>
+#include <boost/fusion/support/ref.hpp>
 
 #endif

--- a/include/boost/fusion/support/ref.hpp
+++ b/include/boost/fusion/support/ref.hpp
@@ -1,0 +1,186 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef BOOST_FUSION_SUPPORT_REF_HPP_INCLUDED
+#define BOOST_FUSION_SUPPORT_REF_HPP_INCLUDED
+
+
+#include <boost/ref.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/fusion/support/tag_of_fwd.hpp>
+
+
+namespace boost { namespace fusion
+{
+    struct reference_wrapper_tag;
+}}
+
+namespace boost { namespace fusion { namespace traits
+{
+    template<typename T>
+    struct tag_of<reference_wrapper<T> >
+    {
+        typedef reference_wrapper_tag type;
+    };
+}}}
+
+namespace boost { namespace fusion { namespace extension
+{
+    template<typename Tag>
+    struct category_of_impl;
+    
+    template<typename Tag>
+    struct begin_impl;
+
+    template<typename Tag>
+    struct end_impl;
+
+    template<typename Tag>
+    struct at_impl;
+
+    template<typename Tag>
+    struct value_at_impl;
+
+    template<typename Tag>
+    struct size_impl;
+
+    template<typename Tag>
+    struct at_key_impl;
+
+    template<typename Tag>
+    struct value_at_key_impl;
+
+    template<typename Tag>
+    struct has_key_impl;
+
+    template<typename Tag>
+    struct is_sequence_impl;
+
+    template<typename Tag>
+    struct is_view_impl;
+
+    template<typename Tag>
+    struct is_segmented_impl;
+    
+    template<>
+    struct category_of_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence>
+        struct apply
+          : category_of_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type>
+        {};
+    };
+    
+    template<>
+    struct begin_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence>
+        struct apply
+          : begin_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type>
+        {};
+    };
+    
+    template<>
+    struct end_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence>
+        struct apply
+          : end_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type>
+        {};
+    };
+
+    template<>
+    struct at_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence, typename N>
+        struct apply
+          : at_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type, N>
+        {};
+    };
+
+    template<>
+    struct value_at_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence, typename N>
+        struct apply
+          : value_at_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type, N>
+        {};
+    };
+
+    template<>
+    struct size_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence>
+        struct apply
+          : size_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type>
+        {};
+    };
+
+    template<>
+    struct value_at_key_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence, typename Key>
+        struct apply
+          : value_at_key_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type, Key>
+        {};
+    };
+
+    template<>
+    struct at_key_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence, typename Key>
+        struct apply
+          : at_key_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type, Key>
+        {};
+    };
+
+    template<>
+    struct has_key_impl<reference_wrapper_tag>
+    {
+        template<typename Sequence, typename Key>
+        struct apply
+          : has_key_impl<typename traits::tag_of<typename Sequence::type>::type>::
+                template apply<typename Sequence::type, Key>
+        {};
+    };
+
+    template<>
+    struct is_sequence_impl<reference_wrapper_tag>
+    {
+        template<typename T>
+        struct apply
+          : is_sequence_impl<typename traits::tag_of<typename T::type>::type>::
+                template apply<typename T::type>
+        {};
+    };
+
+    template<>
+    struct is_view_impl<reference_wrapper_tag>
+      : is_sequence_impl<reference_wrapper_tag>
+    {};
+    
+    template<>
+    struct is_segmented_impl<reference_wrapper_tag>
+    {
+        template<typename T>
+        struct apply
+          : is_segmented_impl<typename traits::tag_of<typename T::type>::type>::
+                template apply<typename T::type>
+        {};
+    };
+}}}
+
+
+#endif
+

--- a/include/boost/fusion/view.hpp
+++ b/include/boost/fusion/view.hpp
@@ -16,5 +16,6 @@
 #include <boost/fusion/view/reverse_view.hpp>
 #include <boost/fusion/view/transform_view.hpp>
 #include <boost/fusion/view/zip_view.hpp>
+#include <boost/fusion/view/flatten_view.hpp>
 
 #endif

--- a/include/boost/fusion/view/flatten_view.hpp
+++ b/include/boost/fusion/view/flatten_view.hpp
@@ -1,0 +1,15 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef BOOST_FUSION_SEQUENCE_FLATTEN_VIEW_HPP_INCLUDED
+#define BOOST_FUSION_SEQUENCE_FLATTEN_VIEW_HPP_INCLUDED
+
+
+#include <boost/fusion/view/flatten_view/flatten_view.hpp>
+#include <boost/fusion/view/flatten_view/flatten_view_iterator.hpp>
+
+
+#endif

--- a/include/boost/fusion/view/flatten_view/flatten_view.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view.hpp
@@ -1,0 +1,127 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef BOOST_FUSION_FLATTEN_VIEW_HPP_INCLUDED
+#define BOOST_FUSION_FLATTEN_VIEW_HPP_INCLUDED
+
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/single_view.hpp>
+#include <boost/fusion/support/detail/access.hpp>
+#include <boost/fusion/support/is_view.hpp>
+#include <boost/fusion/support/category_of.hpp>
+#include <boost/fusion/support/sequence_base.hpp>
+#include <boost/fusion/sequence/intrinsic/begin.hpp>
+#include <boost/fusion/sequence/intrinsic/end.hpp>
+#include <boost/fusion/view/flatten_view/flatten_view_iterator.hpp>
+
+
+namespace boost { namespace fusion
+{
+    struct forward_traversal_tag;
+    struct flatten_view_tag;
+    
+    template <typename Sequence>
+    struct flatten_view
+      : sequence_base<flatten_view<Sequence> >
+    {
+        typedef flatten_view_tag fusion_tag;
+        typedef fusion_sequence_tag tag; // this gets picked up by MPL
+        typedef mpl::true_ is_view;
+        typedef forward_traversal_tag category;
+        
+        typedef Sequence sequence_type;
+        typedef typename result_of::begin<Sequence>::type first_type;
+        typedef typename result_of::end<Sequence>::type last_type;
+        
+        explicit flatten_view(Sequence& seq)
+          : seq(seq)
+        {}
+        
+        first_type first() const { return fusion::begin(seq); }
+        last_type last() const { return fusion::end(seq); }
+        
+        typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
+    };
+}}
+
+namespace boost { namespace fusion { namespace extension
+{
+    template<>
+    struct begin_impl<flatten_view_tag>
+    {
+        template<typename Sequence>
+        struct apply
+        {
+            typedef typename Sequence::first_type first_type;
+            
+            typedef typename
+                    result_of::begin<
+                        mpl::single_view<
+                            typename Sequence::sequence_type> >::type
+            root_iterator;
+            
+            typedef
+                detail::seek_descent<root_iterator, first_type>
+            seek_descent;
+            
+            typedef typename seek_descent::type type;
+
+            static inline
+            type call(Sequence& seq)
+            {
+                return seek_descent::apply(root_iterator(), seq.first());
+            }
+        };
+    };
+    
+    template<>
+    struct end_impl<flatten_view_tag>
+    {
+        template<typename Sequence>
+        struct apply
+        {
+            typedef typename Sequence::last_type last_type;
+            
+            typedef typename
+                    result_of::end<
+                        mpl::single_view<
+                            typename Sequence::sequence_type> >::type
+            type;
+
+            static inline
+            type call(Sequence&)
+            {
+                return type();
+            }
+        };
+    };
+
+    template<>
+    struct size_impl<flatten_view_tag>
+    {
+        template <typename Sequence>
+        struct apply
+          : result_of::distance
+            <
+                typename result_of::begin<Sequence>::type
+              , typename result_of::end<Sequence>::type
+            >
+        {};
+    };
+
+    template<>
+    struct empty_impl<flatten_view_tag>
+    {
+        template <typename Sequence>
+        struct apply
+          : result_of::empty<typename Sequence::sequence_type>
+        {};
+    };
+}}}
+
+
+#endif

--- a/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
@@ -1,0 +1,199 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#ifndef BOOST_FUSION_FLATTEN_VIEW_ITERATOR_HPP_INCLUDED
+#define BOOST_FUSION_FLATTEN_VIEW_ITERATOR_HPP_INCLUDED
+
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/fusion/container/list/cons.hpp>
+#include <boost/fusion/support/unused.hpp>
+#include <boost/fusion/include/equal_to.hpp>
+#include <boost/fusion/iterator/next.hpp>
+#include <boost/fusion/iterator/deref.hpp>
+#include <boost/fusion/iterator/value_of.hpp>
+
+
+namespace boost { namespace fusion
+{
+    struct forward_traversal_tag;
+    struct flatten_view_iterator_tag;
+    
+    template<class First, class Base>
+    struct flatten_view_iterator
+      : iterator_base<flatten_view_iterator<First, Base> >
+    {
+        typedef flatten_view_iterator_tag fusion_tag;
+        typedef forward_traversal_tag category;
+        
+        typedef convert_iterator<First> first_converter;
+        typedef typename first_converter::type first_type;
+        typedef Base base_type;
+        
+        flatten_view_iterator(First const& first, Base const& base)
+          : first(first), base(base)
+        {}
+        
+        first_type first;
+        base_type base;
+    };
+}}
+
+namespace boost { namespace fusion { namespace detail
+{
+    template<class Iterator, class = void>
+    struct make_descent_cons
+    {
+        typedef cons<Iterator> type;
+        
+        static inline type apply(Iterator const& it)
+        {
+            return type(it);
+        }
+    };
+    
+    template<class Iterator>
+    struct make_descent_cons<Iterator,
+        typename enable_if<traits::is_sequence<
+            typename result_of::value_of<Iterator>::type> >::type>
+    {
+        // we use 'value_of' above for convenience, assuming the value won't be reference,
+        // while we must use the regular 'deref' here for const issues...
+        typedef typename
+            remove_reference<typename result_of::deref<Iterator>::type>::type
+        sub_sequence;
+        
+        typedef typename
+            result_of::begin<sub_sequence>::type
+        sub_begin;
+            
+        typedef cons<Iterator, typename make_descent_cons<sub_begin>::type> type;
+        
+        static inline type apply(Iterator const& it)
+        {
+            return type(it, make_descent_cons<sub_begin>::apply(
+                fusion::begin(*it)));
+        }
+    };
+    
+    template<class Cons, class Base>
+    struct build_flatten_view_iterator;
+
+    template<class Car, class Base>
+    struct build_flatten_view_iterator<cons<Car>, Base>
+    {
+        typedef flatten_view_iterator<Car, Base> type;
+        
+        static inline type apply(cons<Car> const& cons, Base const& base)
+        {
+            return type(cons.car, base);
+        }
+    };
+    
+    template<class Car, class Cdr, class Base>
+    struct build_flatten_view_iterator<cons<Car, Cdr>, Base>
+    {
+        typedef flatten_view_iterator<Car, Base> next_base;
+        typedef build_flatten_view_iterator<Cdr, next_base> next;
+        typedef typename next::type type;
+        
+        static inline type apply(cons<Car, Cdr> const& cons, Base const& base)
+        {
+            return next::apply(cons.cdr, next_base(cons.car, base));
+        }
+    };
+    
+    template<class Base, class Iterator, class = void>
+    struct seek_descent
+    {
+        typedef make_descent_cons<Iterator> make_descent_cons_;
+        typedef typename make_descent_cons_::type cons_type;
+        typedef
+            build_flatten_view_iterator<cons_type, Base>
+        build_flatten_view_iterator_;
+        typedef typename build_flatten_view_iterator_::type type;
+        
+        static inline type apply(Base const& base, Iterator const& it)
+        {
+            return build_flatten_view_iterator_::apply(
+                make_descent_cons_::apply(it), base);
+        }
+    };
+    
+    template<class Base, class Iterator>
+    struct seek_descent<Base, Iterator,
+        typename enable_if<
+            result_of::equal_to<Iterator, typename result_of::end<
+                    typename result_of::value_of<Base>::type>::type> >::type>
+    {
+        typedef typename result_of::next<Base>::type type;
+        
+        static inline type apply(Base const& base, Iterator const&)
+        {
+            return fusion::next(base);
+        }
+    };
+}}}
+
+namespace boost { namespace fusion { namespace extension
+{
+    template<>
+    struct next_impl<flatten_view_iterator_tag>
+    {
+        template<typename Iterator>
+        struct apply
+        {
+            typedef typename Iterator::first_type first_type;
+            typedef typename Iterator::base_type base_type;
+            typedef typename result_of::next<first_type>::type next_type;
+            
+            typedef detail::seek_descent<base_type, next_type> seek_descent;
+            typedef typename seek_descent::type type;
+
+            static inline
+            type call(Iterator const& it)
+            {
+                return seek_descent::apply(it.base, fusion::next(it.first));
+            }
+        };
+    };
+    
+    template<>
+    struct deref_impl<flatten_view_iterator_tag>
+    {
+        template<typename Iterator>
+        struct apply
+        {
+            typedef typename
+                result_of::deref<typename Iterator::first_type>::type
+            type;
+
+            static inline
+            type call(Iterator const& it)
+            {
+                return *it.first;
+            }
+        };
+    };
+    
+    template<>
+    struct value_of_impl<flatten_view_iterator_tag>
+    {
+        template<typename Iterator>
+        struct apply
+        { 
+            typedef typename
+                result_of::value_of<typename Iterator::first_type>::type
+            type;
+        };
+    };
+}}}
+
+
+#endif
+

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -54,6 +54,7 @@ project
     [ run algorithm/zip.cpp : : : : ]
     [ run algorithm/zip2.cpp : : : : ]
     [ run algorithm/zip_ignore.cpp : : : : ]
+    [ run algorithm/flatten.cpp : : : : ]
 
     [ run sequence/as_list.cpp :  :  :  : ]
     [ run sequence/as_map.cpp :  :  :  : ]
@@ -151,6 +152,7 @@ project
     [ run sequence/define_assoc_tpl_struct.cpp : : : : ]
     [ run sequence/std_tuple_iterator.cpp : : : : ]
     [ run sequence/ref_vector.cpp : : : : ]
+    [ run sequence/flatten_view.cpp : : : : ]
 
     [ run functional/fused.cpp : : : : ]
     [ run functional/fused_function_object.cpp : : : : ]

--- a/test/algorithm/flatten.cpp
+++ b/test/algorithm/flatten.cpp
@@ -1,0 +1,57 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/fusion/container/vector/vector.hpp>
+#include <boost/fusion/sequence/io/out.hpp>
+#include <boost/fusion/sequence/comparison/equal_to.hpp>
+#include <boost/fusion/container/generation/make_vector.hpp>
+#include <boost/fusion/sequence/intrinsic/begin.hpp>
+#include <boost/fusion/sequence/intrinsic/end.hpp>
+#include <boost/fusion/sequence/intrinsic/at.hpp>
+#include <boost/fusion/sequence/intrinsic/size.hpp>
+#include <boost/fusion/iterator/advance.hpp>
+#include <boost/fusion/iterator/deref.hpp>
+#include <boost/fusion/iterator/distance.hpp>
+#include <boost/fusion/algorithm/auxiliary/copy.hpp>
+#include <boost/fusion/algorithm/transformation/flatten.hpp>
+
+
+int main()
+{
+    using namespace boost::fusion;
+
+    {
+        typedef vector<int, int, vector<int, int>, int> sequence_type;
+        sequence_type seq(1, 2, make_vector(3, 4), 5);
+
+        BOOST_TEST((boost::fusion::size(flatten(seq)) == 5));
+    }
+        
+    {
+        typedef vector<int, int, vector<int, int>, int> sequence_type;
+        sequence_type seq(1, 2, make_vector(3, 4), 5);
+        std::cout << flatten(seq) << std::endl;
+        BOOST_TEST((flatten(seq) == make_vector(1, 2, 3, 4, 5)));
+    }
+
+    {
+        std::cout << flatten(make_vector(1, 2, make_vector(3, 4), 5)) << std::endl;
+        BOOST_TEST((flatten(make_vector(1, 2, make_vector(3, 4), 5)) == make_vector(1, 2, 3, 4, 5)));
+    }
+    
+    {
+        typedef vector<int, int, vector<int, int>, int> sequence_type;
+        sequence_type seq;
+        result_of::flatten<sequence_type>::type flat(flatten(seq));
+        copy(make_vector(1, 2, 3, 4, 5), flat);
+        std::cout << seq << std::endl;
+        BOOST_TEST((seq == make_vector(1, 2, make_vector(3, 4), 5)));
+    }
+    
+    return boost::report_errors();
+}
+

--- a/test/sequence/flatten_view.cpp
+++ b/test/sequence/flatten_view.cpp
@@ -1,0 +1,56 @@
+/*//////////////////////////////////////////////////////////////////////////////
+    Copyright (c) 2013 Jamboree
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//////////////////////////////////////////////////////////////////////////////*/
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/fusion/container/vector/vector.hpp>
+#include <boost/fusion/view/flatten_view/flatten_view.hpp>
+#include <boost/fusion/sequence/io/out.hpp>
+#include <boost/fusion/sequence/comparison/equal_to.hpp>
+#include <boost/fusion/container/generation/make_vector.hpp>
+#include <boost/fusion/sequence/intrinsic/begin.hpp>
+#include <boost/fusion/sequence/intrinsic/end.hpp>
+#include <boost/fusion/sequence/intrinsic/at.hpp>
+#include <boost/fusion/sequence/intrinsic/size.hpp>
+#include <boost/fusion/iterator/advance.hpp>
+#include <boost/fusion/iterator/deref.hpp>
+#include <boost/fusion/iterator/distance.hpp>
+#include <boost/fusion/algorithm/auxiliary/copy.hpp>
+
+
+int main()
+{
+    using namespace boost::fusion;
+
+    {
+        typedef vector<int, int, vector<int, int>, int> sequence_type;
+        sequence_type seq(1, 2, make_vector(3, 4), 5);
+        flatten_view<sequence_type> flattened(seq);
+
+        BOOST_TEST((boost::fusion::size(flattened) == 5));
+        BOOST_TEST((boost::fusion::distance(boost::fusion::begin(flattened), boost::fusion::end(flattened)) == 5));
+    }
+        
+    {
+        typedef vector<int, int, vector<int, int>, int> sequence_type;
+        sequence_type seq(1, 2, make_vector(3, 4), 5);
+        flatten_view<sequence_type> flattened(seq);
+        std::cout << flattened << std::endl;
+        BOOST_TEST((flattened == make_vector(1, 2, 3, 4, 5)));
+        BOOST_TEST((*advance_c<2>(boost::fusion::begin(flattened)) == 3));
+    }
+
+    {
+        typedef vector<int, int, vector<int, int>, int> sequence_type;
+        sequence_type seq;
+        flatten_view<sequence_type> flattened(seq);
+        copy(make_vector(1, 2, 3, 4, 5), flattened);
+        std::cout << seq << std::endl;
+        BOOST_TEST((seq == make_vector(1, 2, make_vector(3, 4), 5)));
+    }
+    
+    return boost::report_errors();
+}
+


### PR DESCRIPTION
New algorithm 'flatten' & view type 'flatten_view', plus support for boost::ref for working with mutable sequence.

Adapted from https://svn.boost.org/trac/boost/ticket/9294
