### PR TITLE
Fix test error in msvc-10.0

### DIFF
--- a/test/sequence/std_tuple.cpp
+++ b/test/sequence/std_tuple.cpp
@@ -7,7 +7,9 @@
 
 #include <boost/config.hpp>
 
-#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+// adapted/std_tuple.hpp only supports implementations using variadic templates
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE) && \
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
 
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/fusion/adapted/std_tuple.hpp>
@@ -23,15 +25,12 @@ main()
     using namespace boost::fusion;
     using namespace boost;
 
-// The convert only supports implementations using variadic templates
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     {
         // conversion vector to std tuple
         std::tuple<int, std::string> t = convert<std_tuple_tag>(make_vector(123, "Hola!!!"));
         BOOST_TEST(std::get<0>(t) == 123);
         BOOST_TEST(std::get<1>(t) == "Hola!!!");
     }
-#endif
 
     return boost::report_errors();
 }


### PR DESCRIPTION
My previous PR(#7)'s test will occur compile error in msvc-10.0, since it doesn't support variadic templates.
Thus, entire test should be ignored if variadic templates isn't supported.

failed test: http://www.boost.org/development/tests/develop/developer/output/teeks99-02c-win2008-64on64-boost-bin-v2-libs-fusion-test-std_tuple-test-msvc-10-0-debug-threading-multi.html
