### PR TITLE
Fixes the DEFINE_STRUCT* macros after addition of type deduction for ADAPT_STRUCT

### DIFF
--- a/include/boost/fusion/adapted/struct/define_struct.hpp
+++ b/include/boost/fusion/adapted/struct/define_struct.hpp
@@ -19,7 +19,7 @@
         TEMPLATE_PARAMS_SEQ,                                                    \
         (0)NAMESPACE_SEQ,                                                       \
         NAME,                                                                   \
-        BOOST_PP_CAT(BOOST_FUSION_ADAPT_STRUCT_FILLER_0(0,0)ATTRIBUTES,_END),   \
+        BOOST_PP_CAT(BOOST_FUSION_DEFINE_STRUCT_FILLER_0(0,0)ATTRIBUTES,_END),  \
         2)                                                                      \
                                                                                 \
     BOOST_FUSION_ADAPT_TPL_STRUCT(                                              \
@@ -32,7 +32,7 @@
     BOOST_FUSION_DEFINE_STRUCT_IMPL(                                            \
         (0)NAMESPACE_SEQ,                                                       \
         NAME,                                                                   \
-        BOOST_PP_CAT(BOOST_FUSION_ADAPT_STRUCT_FILLER_0(0,0)ATTRIBUTES,_END),   \
+        BOOST_PP_CAT(BOOST_FUSION_DEFINE_STRUCT_FILLER_0(0,0)ATTRIBUTES,_END),  \
         2)                                                                      \
                                                                                 \
     BOOST_FUSION_ADAPT_STRUCT(                                                  \

--- a/include/boost/fusion/adapted/struct/detail/define_struct.hpp
+++ b/include/boost/fusion/adapted/struct/detail/define_struct.hpp
@@ -34,6 +34,13 @@
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#define BOOST_FUSION_DEFINE_STRUCT_FILLER_0(X, Y)                               \
+    ((X, Y)) BOOST_FUSION_DEFINE_STRUCT_FILLER_1
+#define BOOST_FUSION_DEFINE_STRUCT_FILLER_1(X, Y)                               \
+    ((X, Y)) BOOST_FUSION_DEFINE_STRUCT_FILLER_0
+#define BOOST_FUSION_DEFINE_STRUCT_FILLER_0_END
+#define BOOST_FUSION_DEFINE_STRUCT_FILLER_1_END
+
 #define BOOST_FUSION_DEFINE_STRUCT_COPY_CTOR_FILLER_I(                          \
     R, ATTRIBUTE_TUPEL_SIZE, I, ATTRIBUTE)                                      \
                                                                                 \

--- a/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
+++ b/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
@@ -301,7 +301,7 @@
 #define BOOST_FUSION_DEFINE_STRUCT_INLINE_MEMBERS(NAME, ATTRIBUTES)             \
     BOOST_FUSION_DEFINE_STRUCT_MEMBERS_IMPL(                                    \
         NAME,                                                                   \
-        BOOST_PP_CAT(BOOST_FUSION_ADAPT_STRUCT_FILLER_0 ATTRIBUTES,_END))
+        BOOST_PP_CAT(BOOST_FUSION_DEFINE_STRUCT_FILLER_0 ATTRIBUTES,_END))
 
 // Note: can't compute BOOST_PP_SEQ_SIZE(ATTRIBUTES_SEQ) directly because
 //       ATTRIBUTES_SEQ may be empty and calling BOOST_PP_SEQ_SIZE on an empty
@@ -315,7 +315,7 @@
 #define BOOST_FUSION_DEFINE_STRUCT_INLINE_ITERATOR(NAME, ATTRIBUTES)            \
     BOOST_FUSION_DEFINE_STRUCT_ITERATOR_IMPL(                                   \
         NAME,                                                                   \
-        BOOST_PP_CAT(BOOST_FUSION_ADAPT_STRUCT_FILLER_0 ATTRIBUTES,_END))
+        BOOST_PP_CAT(BOOST_FUSION_DEFINE_STRUCT_FILLER_0 ATTRIBUTES,_END))
 
 #define BOOST_FUSION_DEFINE_STRUCT_ITERATOR_IMPL(NAME, ATTRIBUTES_SEQ)          \
     BOOST_FUSION_DEFINE_STRUCT_INLINE_ITERATOR_IMPL_IMPL(                       \


### PR DESCRIPTION
Hi @djowel and @K-ballo,

As I told in pull-request #9 the BOOST_FUSION_DEFINE_STRUCT macros were broken by my changes. This small commit fixes this problem. This way all tests are passing now.

As the BOOST_FUSION_ADAPT_STRUCT_FILLER\* macros were changed to handle type deduction, this breaks the usage that BOOST_FUSION_DEFINE_STRUCT makes from them.

That is because BOOST_FUSION_DEFINE_STRUCT expects a simple tuple per attribute, while we now provide a tuple containing the size of a nested tuple which either has or not the type provided ( _i.e._ ((2, (member_type0, member_name0))) ). But in the case of the DEFINE\* macros it would be a non-sense to support this kind of API as a field being currently defined cannot be deduced. :)

Cheers
