### PR TITLE
Initial constexpr support

### DIFF
--- a/include/boost/fusion/adapted/mpl/detail/at_impl.hpp
+++ b/include/boost/fusion/adapted/mpl/detail/at_impl.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace fusion
             {
                 typedef typename mpl::at<Sequence, N>::type type;
                 
-                BOOST_FUSION_GPU_ENABLED
+                BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
                 static type
                 call(Sequence)
                 {

--- a/include/boost/fusion/adapted/mpl/detail/begin_impl.hpp
+++ b/include/boost/fusion/adapted/mpl/detail/begin_impl.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace fusion {
                 >::type iterator;
                 typedef mpl_iterator<iterator> type;
                 
-                BOOST_FUSION_GPU_ENABLED
+                BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
                 static type
                 call(Sequence)
                 {

--- a/include/boost/fusion/adapted/mpl/detail/end_impl.hpp
+++ b/include/boost/fusion/adapted/mpl/detail/end_impl.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace fusion
                 >::type iterator;
                 typedef mpl_iterator<iterator> type;
                 
-                BOOST_FUSION_GPU_ENABLED
+                BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
                 static type
                 call(Sequence)
                 {

--- a/include/boost/fusion/adapted/mpl/mpl_iterator.hpp
+++ b/include/boost/fusion/adapted/mpl/mpl_iterator.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace fusion
                 typename Iterator::iterator_type>::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator)
             {
@@ -53,7 +53,7 @@ namespace boost { namespace fusion
                 typename mpl::next<typename Iterator::iterator_type>::type> 
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator)
             {
@@ -68,7 +68,7 @@ namespace boost { namespace fusion
                 typename mpl::prior<typename Iterator::iterator_type>::type> 
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator)
             {
@@ -83,7 +83,7 @@ namespace boost { namespace fusion
                 typename mpl::advance<typename Iterator::iterator_type, N>::type>
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator const& /*i*/)
             {
@@ -104,7 +104,7 @@ namespace boost { namespace fusion
                 >::type
             type;
             
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(I1 const&, I2 const&)
             {

--- a/include/boost/fusion/algorithm/iteration/detail/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/fold.hpp
@@ -58,7 +58,7 @@ namespace boost { namespace fusion
         struct BOOST_PP_CAT(unrolled_,BOOST_FUSION_FOLD_NAME)
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -104,7 +104,7 @@ namespace boost { namespace fusion
         struct BOOST_PP_CAT(unrolled_,BOOST_FUSION_FOLD_NAME)<Result,3>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -135,7 +135,7 @@ namespace boost { namespace fusion
         struct BOOST_PP_CAT(unrolled_,BOOST_FUSION_FOLD_NAME)<Result,2>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -153,7 +153,7 @@ namespace boost { namespace fusion
         struct BOOST_PP_CAT(unrolled_,BOOST_FUSION_FOLD_NAME)<Result,1>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -166,7 +166,7 @@ namespace boost { namespace fusion
         struct BOOST_PP_CAT(unrolled_,BOOST_FUSION_FOLD_NAME)<Result,0>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const&, F)
             {
@@ -345,7 +345,7 @@ namespace boost { namespace fusion
                 >::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(StateRef state, Seq& seq, F f)
             {
@@ -369,7 +369,7 @@ namespace boost { namespace fusion
         {
             typedef StateRef type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static StateRef
             call(StateRef state, Seq&, F)
             {
@@ -404,7 +404,7 @@ namespace boost { namespace fusion
     }
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::BOOST_FUSION_FOLD_NAME<
         Seq
       , State const
@@ -419,7 +419,7 @@ namespace boost { namespace fusion
     }
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::BOOST_FUSION_FOLD_NAME<
         Seq const
       , State const
@@ -434,7 +434,7 @@ namespace boost { namespace fusion
     }
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::BOOST_FUSION_FOLD_NAME<
         Seq
       , State const
@@ -449,7 +449,7 @@ namespace boost { namespace fusion
     }
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::BOOST_FUSION_FOLD_NAME<
         Seq const
       , State const

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/fold.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace fusion
         struct unrolled_fold
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -65,7 +65,7 @@ namespace boost { namespace fusion
         struct unrolled_fold<Result,3>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -92,7 +92,7 @@ namespace boost { namespace fusion
         struct unrolled_fold<Result,2>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -107,7 +107,7 @@ namespace boost { namespace fusion
         struct unrolled_fold<Result,1>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const& it0,F f)
             {
@@ -119,7 +119,7 @@ namespace boost { namespace fusion
         struct unrolled_fold<Result,0>
         {
             template<typename State, typename It0, typename F>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static Result
             call(State const& state,It0 const&, F)
             {
@@ -282,7 +282,7 @@ namespace boost { namespace fusion
                   , SeqSize
                 >::type
             type;
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(StateRef state, Seq& seq, F f)
             {
@@ -302,7 +302,7 @@ namespace boost { namespace fusion
         struct fold_impl<0,StateRef,Seq,F>
         {
             typedef StateRef type;
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static StateRef
             call(StateRef state, Seq&, F)
             {
@@ -334,7 +334,7 @@ namespace boost { namespace fusion
         {};
     }
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::fold<
         Seq
       , State const
@@ -348,7 +348,7 @@ namespace boost { namespace fusion
             f);
     }
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::fold<
         Seq const
       , State const
@@ -362,7 +362,7 @@ namespace boost { namespace fusion
             f);
     }
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::fold<
         Seq
       , State const
@@ -376,7 +376,7 @@ namespace boost { namespace fusion
             f);
     }
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::fold<
         Seq const
       , State const

--- a/include/boost/fusion/algorithm/iteration/fold_fwd.hpp
+++ b/include/boost/fusion/algorithm/iteration/fold_fwd.hpp
@@ -17,7 +17,7 @@ namespace boost { namespace fusion
     }
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::fold<
         Seq
       , State const
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
     fold(Seq& seq, State const& state, F f);
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::fold<
         Seq const
       , State const
@@ -35,7 +35,7 @@ namespace boost { namespace fusion
     fold(Seq const& seq, State const& state, F f);
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::fold<
         Seq
       , State const
@@ -44,7 +44,7 @@ namespace boost { namespace fusion
     fold(Seq& seq, State& state, F f);
 
     template<typename Seq, typename State, typename F>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::fold<
         Seq const
       , State const

--- a/include/boost/fusion/iterator/advance.hpp
+++ b/include/boost/fusion/iterator/advance.hpp
@@ -75,7 +75,7 @@ namespace boost { namespace fusion
     }
 
     template <int N, typename Iterator>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::advance_c<Iterator, N>::type const
     advance_c(Iterator const& i)
     {
@@ -83,7 +83,7 @@ namespace boost { namespace fusion
     }
 
     template<typename N, typename Iterator>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::advance<Iterator, N>::type const
     advance(Iterator const& i)
     {

--- a/include/boost/fusion/iterator/basic_iterator.hpp
+++ b/include/boost/fusion/iterator/basic_iterator.hpp
@@ -77,7 +77,7 @@ namespace boost { namespace fusion
                 basic_iterator<Tag, Category, Seq, Index + N::value>
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(It const& it)
             {
@@ -100,7 +100,7 @@ namespace boost { namespace fusion
         {
             typedef mpl::minus<typename It2::index, typename It1::index> type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static
             type
             call(It1 const&, It2 const&)
@@ -121,18 +121,18 @@ namespace boost { namespace fusion
         {};
 
         template<typename OtherSeq>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         basic_iterator(basic_iterator<Tag,Category,OtherSeq,Index> const& it)
           : seq(it.seq)
         {}
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         basic_iterator(Seq& in_seq, int)
           : seq(&in_seq)
         {}
 
         template<typename OtherSeq>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         basic_iterator&
         operator=(basic_iterator<Tag,Category,OtherSeq,Index> const& it)
         {

--- a/include/boost/fusion/iterator/deref.hpp
+++ b/include/boost/fusion/iterator/deref.hpp
@@ -55,7 +55,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Iterator>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::deref<Iterator>::type
     deref(Iterator const& i)
     {
@@ -64,7 +64,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Iterator>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::deref<Iterator>::type
     operator*(iterator_base<Iterator> const& i)
     {

--- a/include/boost/fusion/iterator/deref_data.hpp
+++ b/include/boost/fusion/iterator/deref_data.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
     }
 
     template <typename It>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::deref_data<It>::type
     deref_data(It const& it)
     {

--- a/include/boost/fusion/iterator/detail/adapt_deref_traits.hpp
+++ b/include/boost/fusion/iterator/detail/adapt_deref_traits.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace fusion { namespace detail
                 result_of::deref<typename Iterator::first_type>::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator const& i)
             {

--- a/include/boost/fusion/iterator/detail/advance.hpp
+++ b/include/boost/fusion/iterator/detail/advance.hpp
@@ -45,7 +45,7 @@ namespace boost { namespace fusion { namespace advance_detail
             >::type
         type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type const&
         call(type const& i)
         {
@@ -53,7 +53,7 @@ namespace boost { namespace fusion { namespace advance_detail
         }
 
         template <typename I>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type
         call(I const& i)
         {
@@ -86,7 +86,7 @@ namespace boost { namespace fusion { namespace advance_detail
             >::type
         type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type const&
         call(type const& i)
         {
@@ -94,7 +94,7 @@ namespace boost { namespace fusion { namespace advance_detail
         }
 
         template <typename I>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type
         call(I const& i)
         {

--- a/include/boost/fusion/iterator/detail/distance.hpp
+++ b/include/boost/fusion/iterator/detail/distance.hpp
@@ -53,7 +53,7 @@ namespace boost { namespace fusion { namespace distance_detail
             >::type
         type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type
         call(First const&, Last const&)
         {

--- a/include/boost/fusion/iterator/detail/segment_sequence.hpp
+++ b/include/boost/fusion/iterator/detail/segment_sequence.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion { namespace detail
         typedef Sequence sequence_type;
         sequence_type sequence;
 
-        BOOST_FUSION_GPU_ENABLED explicit segment_sequence(Sequence const & seq)
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED explicit segment_sequence(Sequence const & seq)
             : sequence(seq)
         {}
     };
@@ -61,7 +61,7 @@ namespace extension
         {
             typedef typename Sequence::sequence_type type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Sequence & seq)
             {
                 return seq.sequence;

--- a/include/boost/fusion/iterator/detail/segmented_iterator.hpp
+++ b/include/boost/fusion/iterator/detail/segmented_iterator.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace fusion
     struct segmented_iterator
       : iterator_facade<segmented_iterator<Context>, forward_traversal_tag>
     {
-        BOOST_FUSION_GPU_ENABLED explicit segmented_iterator(Context const& ctx)
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED explicit segmented_iterator(Context const& ctx)
           : context(ctx)
         {}
 
@@ -52,7 +52,7 @@ namespace boost { namespace fusion
                 >::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(It const& it)
             {
                 return *it.context.car.first;
@@ -72,7 +72,7 @@ namespace boost { namespace fusion
                 >::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(It const& it)
             {
                 return fusion::deref_data(it.context.car.first);
@@ -132,7 +132,7 @@ namespace boost { namespace fusion
             typedef detail::segmented_next_impl<typename It::context_type> impl;
             typedef segmented_iterator<typename impl::type> type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(It const& it)
             {
                 return type(impl::call(it.context));

--- a/include/boost/fusion/iterator/detail/segmented_next_impl.hpp
+++ b/include/boost/fusion/iterator/detail/segmented_next_impl.hpp
@@ -65,7 +65,7 @@ namespace boost { namespace fusion
                 cons<car_type, typename Stack::cdr_type>
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return type(
@@ -98,7 +98,7 @@ namespace boost { namespace fusion
             typedef segmented_next_impl_recurse<typename Stack::cdr_type> impl;
             typedef typename impl::type type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return impl::call(stack.cdr);
@@ -112,7 +112,7 @@ namespace boost { namespace fusion
             typedef iterator_range<end_type, end_type> range_type;
             typedef cons<range_type> type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return type(range_type(stack.car.last, stack.car.last));
@@ -147,7 +147,7 @@ namespace boost { namespace fusion
             typedef segmented_next_impl_recurse3<Stack> impl;
             typedef typename impl::type type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return impl::call(stack);
@@ -159,7 +159,7 @@ namespace boost { namespace fusion
         {
             typedef Result type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return segmented_begin_impl<Sequence, Stack>::call(*stack.car.first, stack);
@@ -185,7 +185,7 @@ namespace boost { namespace fusion
                 typename segmented_next_impl_recurse<typename Stack::cdr_type>::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const& stack)
             {
                 return segmented_next_impl_recurse<typename Stack::cdr_type>::call(stack.cdr);
@@ -197,7 +197,7 @@ namespace boost { namespace fusion
         {
             typedef Next type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return pop_front_car<Stack>::call(stack);
@@ -210,7 +210,7 @@ namespace boost { namespace fusion
             typedef segmented_next_impl_recurse2<Next> impl;
             typedef typename impl::type type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return impl::call(pop_front_car<Stack>::call(stack));
@@ -236,7 +236,7 @@ namespace boost { namespace fusion
             typedef segmented_next_impl_recurse<typename Stack::cdr_type> impl;
             typedef typename impl::type type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return impl::call(stack.cdr);
@@ -248,7 +248,7 @@ namespace boost { namespace fusion
         {
             typedef Next type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Stack const & stack)
             {
                 return pop_front_car<Stack>::call(stack);

--- a/include/boost/fusion/iterator/distance.hpp
+++ b/include/boost/fusion/iterator/distance.hpp
@@ -69,7 +69,7 @@ namespace boost { namespace fusion
     }
         
     template <typename First, typename Last>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::distance<First, Last>::type
     distance(First const& a, Last const& b)
     {

--- a/include/boost/fusion/iterator/equal_to.hpp
+++ b/include/boost/fusion/iterator/equal_to.hpp
@@ -74,7 +74,7 @@ namespace boost { namespace fusion
     namespace iterator_operators
     {
         template <typename Iter1, typename Iter2>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         inline typename
         boost::enable_if<
             mpl::and_<is_fusion_iterator<Iter1>, is_fusion_iterator<Iter2> >
@@ -86,7 +86,7 @@ namespace boost { namespace fusion
         }
 
         template <typename Iter1, typename Iter2>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         inline typename
         boost::enable_if<
             mpl::and_<is_fusion_iterator<Iter1>, is_fusion_iterator<Iter2> >

--- a/include/boost/fusion/iterator/iterator_adapter.hpp
+++ b/include/boost/fusion/iterator/iterator_adapter.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace fusion
         iterator_base_type;
         iterator_base_type iterator_base;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         iterator_adapter(iterator_base_type const& iterator_base_)
             : iterator_base(iterator_base_) {}
 
@@ -47,7 +47,7 @@ namespace boost { namespace fusion
                 >::type>::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator const& it)
             {
@@ -82,7 +82,7 @@ namespace boost { namespace fusion
                 >::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator const& it)
             {
@@ -100,7 +100,7 @@ namespace boost { namespace fusion
                 >::type>::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator const& i)
             {
@@ -118,7 +118,7 @@ namespace boost { namespace fusion
                 >::type>::type
             type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
             call(Iterator const& i)
             {

--- a/include/boost/fusion/iterator/mpl/convert_iterator.hpp
+++ b/include/boost/fusion/iterator/mpl/convert_iterator.hpp
@@ -31,21 +31,21 @@ namespace boost { namespace fusion
             >::type
         type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static T const&
         call(T const& x, mpl::true_)
         {
             return x;
         }
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static mpl_iterator<T>
         call(T const& /*x*/, mpl::false_)
         {
             return mpl_iterator<T>();
         }
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static typename
             mpl::if_<
                 is_fusion_iterator<T>

--- a/include/boost/fusion/iterator/next.hpp
+++ b/include/boost/fusion/iterator/next.hpp
@@ -54,7 +54,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Iterator>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::next<Iterator>::type const
     next(Iterator const& i)
     {

--- a/include/boost/fusion/iterator/prior.hpp
+++ b/include/boost/fusion/iterator/prior.hpp
@@ -54,7 +54,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Iterator>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::prior<Iterator>::type const
     prior(Iterator const& i)
     {

--- a/include/boost/fusion/sequence/intrinsic/at.hpp
+++ b/include/boost/fusion/sequence/intrinsic/at.hpp
@@ -72,7 +72,7 @@ namespace boost { namespace fusion
 
 
     template <typename N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_disable_if<
             is_const<Sequence>
@@ -84,7 +84,7 @@ namespace boost { namespace fusion
     }
 
     template <typename N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::at<Sequence const, N>::type
     at(Sequence const& seq)
     {
@@ -92,7 +92,7 @@ namespace boost { namespace fusion
     }
 
     template <int N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_disable_if<
             is_const<Sequence>
@@ -104,7 +104,7 @@ namespace boost { namespace fusion
     }
 
     template <int N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::at_c<Sequence const, N>::type
     at_c(Sequence const& seq)
     {

--- a/include/boost/fusion/sequence/intrinsic/at_key.hpp
+++ b/include/boost/fusion/sequence/intrinsic/at_key.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace fusion
                     >::type
                 type;
 
-                BOOST_FUSION_GPU_ENABLED
+                BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
                 static type
                 call(Seq& seq)
                 {
@@ -74,7 +74,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Key, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename 
         lazy_disable_if<
             is_const<Sequence>
@@ -86,7 +86,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Key, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::at_key<Sequence const, Key>::type
     at_key(Sequence const& seq)
     {

--- a/include/boost/fusion/sequence/intrinsic/back.hpp
+++ b/include/boost/fusion/sequence/intrinsic/back.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace fusion
     }
     
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::back<Sequence>::type
     back(Sequence& seq)
     {
@@ -35,7 +35,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::back<Sequence const>::type
     back(Sequence const& seq)
     {

--- a/include/boost/fusion/sequence/intrinsic/begin.hpp
+++ b/include/boost/fusion/sequence/intrinsic/begin.hpp
@@ -71,7 +71,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_enable_if<
             traits::is_sequence<Sequence>
@@ -83,7 +83,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_enable_if<
             traits::is_sequence<Sequence>

--- a/include/boost/fusion/sequence/intrinsic/detail/segmented_begin.hpp
+++ b/include/boost/fusion/sequence/intrinsic/detail/segmented_begin.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace fusion { namespace detail
             >
         type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type call(Sequence& seq)
         {
             return type(

--- a/include/boost/fusion/sequence/intrinsic/detail/segmented_begin_impl.hpp
+++ b/include/boost/fusion/sequence/intrinsic/detail/segmented_begin_impl.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace fusion { namespace detail
             typedef cons<range_type, Context> type;
             typedef mpl::false_ continue_type;
 
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type call(Sequence& seq, State const&, Context const& context, segmented_begin_fun)
             {
                 return type(range_type(fusion::begin(seq), fusion::end(seq)), context);
@@ -64,7 +64,7 @@ namespace boost { namespace fusion { namespace detail
 
         typedef typename fold_impl::type type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type call(Sequence& seq, Stack const& stack)
         {
             return fold_impl::call(seq, end_impl::call(seq, stack), stack, segmented_begin_fun());
@@ -79,7 +79,7 @@ namespace boost { namespace fusion { namespace detail
         typedef iterator_range<begin_type, end_type>    pair_type;
         typedef cons<pair_type, Stack>                  type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type call(Sequence& seq, Stack stack)
         {
             return type(pair_type(fusion::begin(seq), fusion::end(seq)), stack);

--- a/include/boost/fusion/sequence/intrinsic/detail/segmented_end.hpp
+++ b/include/boost/fusion/sequence/intrinsic/detail/segmented_end.hpp
@@ -28,7 +28,7 @@ namespace boost { namespace fusion { namespace detail
             >
         type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type call(Sequence & seq)
         {
             return type(

--- a/include/boost/fusion/sequence/intrinsic/detail/segmented_end_impl.hpp
+++ b/include/boost/fusion/sequence/intrinsic/detail/segmented_end_impl.hpp
@@ -48,7 +48,7 @@ namespace boost { namespace fusion { namespace detail
         typedef iterator_range<end_type, end_type>  pair_type;
         typedef cons<pair_type, Stack>              type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type call(Sequence & seq, Stack stack)
         {
             end_type end = fusion::end(fusion::segments(seq));

--- a/include/boost/fusion/sequence/intrinsic/empty.hpp
+++ b/include/boost/fusion/sequence/intrinsic/empty.hpp
@@ -51,7 +51,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::empty<Sequence>::type
     empty(Sequence const&)
     {

--- a/include/boost/fusion/sequence/intrinsic/end.hpp
+++ b/include/boost/fusion/sequence/intrinsic/end.hpp
@@ -71,7 +71,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_enable_if<
             traits::is_sequence<Sequence>
@@ -83,7 +83,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_enable_if<
             traits::is_sequence<Sequence>

--- a/include/boost/fusion/sequence/intrinsic/front.hpp
+++ b/include/boost/fusion/sequence/intrinsic/front.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
     }
     
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::front<Sequence>::type
     front(Sequence& seq)
     {
@@ -34,7 +34,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::front<Sequence const>::type
     front(Sequence const& seq)
     {

--- a/include/boost/fusion/sequence/intrinsic/has_key.hpp
+++ b/include/boost/fusion/sequence/intrinsic/has_key.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Key, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::has_key<Sequence, Key>::type
     has_key(Sequence const&)
     {

--- a/include/boost/fusion/sequence/intrinsic/segments.hpp
+++ b/include/boost/fusion/sequence/intrinsic/segments.hpp
@@ -54,7 +54,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename
         lazy_disable_if<
             is_const<Sequence>
@@ -67,7 +67,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::segments<Sequence const>::type
     segments(Sequence const& seq)
     {

--- a/include/boost/fusion/sequence/intrinsic/size.hpp
+++ b/include/boost/fusion/sequence/intrinsic/size.hpp
@@ -78,7 +78,7 @@ namespace boost { namespace fusion
     }
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::size<Sequence>::type
     size(Sequence const&)
     {

--- a/include/boost/fusion/sequence/intrinsic/swap.hpp
+++ b/include/boost/fusion/sequence/intrinsic/swap.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion {
             };
 
             template<typename Elem>
-            BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             void operator()(Elem const& e) const
             {
                 using std::swap;
@@ -50,7 +50,7 @@ namespace boost { namespace fusion {
     }
 
     template<typename Seq1, typename Seq2>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename enable_if<mpl::and_<traits::is_sequence<Seq1>, traits::is_sequence<Seq2> >, void>::type 
     swap(Seq1& lhs, Seq2& rhs)
     {

--- a/include/boost/fusion/sequence/intrinsic_fwd.hpp
+++ b/include/boost/fusion/sequence/intrinsic_fwd.hpp
@@ -93,7 +93,7 @@ namespace boost { namespace fusion
     }
 
     template <typename N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename 
         lazy_disable_if<
             is_const<Sequence>
@@ -102,12 +102,12 @@ namespace boost { namespace fusion
     at(Sequence& seq);
 
     template <typename N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::at<Sequence const, N>::type
     at(Sequence const& seq);
 
     template <int N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename 
         lazy_disable_if<
             is_const<Sequence>
@@ -116,22 +116,22 @@ namespace boost { namespace fusion
     at_c(Sequence& seq);
 
     template <int N, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::at_c<Sequence const, N>::type
     at_c(Sequence const& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::back<Sequence>::type
     back(Sequence& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::back<Sequence const>::type
     back(Sequence const& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename
         lazy_enable_if<
             traits::is_sequence<Sequence>
@@ -140,7 +140,7 @@ namespace boost { namespace fusion
     begin(Sequence& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename
         lazy_enable_if<
             traits::is_sequence<Sequence>
@@ -149,12 +149,12 @@ namespace boost { namespace fusion
     begin(Sequence const& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::empty<Sequence>::type
     empty(Sequence const&);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename
         lazy_enable_if<
             traits::is_sequence<Sequence>
@@ -163,7 +163,7 @@ namespace boost { namespace fusion
     end(Sequence& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename
         lazy_enable_if<
             traits::is_sequence<Sequence>
@@ -172,22 +172,22 @@ namespace boost { namespace fusion
     end(Sequence const& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::front<Sequence>::type
     front(Sequence& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::front<Sequence const>::type
     front(Sequence const& seq);
 
     template <typename Key, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::has_key<Sequence, Key>::type
     has_key(Sequence const& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename
         lazy_disable_if<
             is_const<Sequence>
@@ -196,17 +196,17 @@ namespace boost { namespace fusion
     segments(Sequence& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::segments<Sequence const>::type
     segments(Sequence const& seq);
 
     template <typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::size<Sequence>::type
     size(Sequence const&);
 
     template <typename Key, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename 
         lazy_disable_if<
             is_const<Sequence>
@@ -215,7 +215,7 @@ namespace boost { namespace fusion
     at_key(Sequence& seq);
 
     template <typename Key, typename Sequence>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename result_of::at_key<Sequence const, Key>::type
     at_key(Sequence const& seq);
 }}


### PR DESCRIPTION
This allows to use, e.g., boost::fusion::fold within constexpr functions.

The BOOST_CONSTEXPR macro is used to declare functions constexpr.
