### PR TITLE
Change to test std::tuple now that Boost.TR1 is deprecated

### DIFF
--- a/test/sequence/tr1_tuple_auto_conv.cpp
+++ b/test/sequence/tr1_tuple_auto_conv.cpp
@@ -1,5 +1,5 @@
-#include <boost/tr1/memory.hpp>
-#include <boost/tr1/tuple.hpp>
+#include <memory>
+#include <tuple>
 #include <boost/any.hpp>
 #include <iostream>
 
@@ -7,10 +7,10 @@ namespace Core
 {
     class AutoConverter
     {
-        std::tr1::shared_ptr<boost::any> t_;
+        std::shared_ptr<boost::any> t_;
 
     public:
-        AutoConverter(std::tr1::shared_ptr<boost::any> const & t)
+        AutoConverter(std::shared_ptr<boost::any> const & t)
             : t_(t)
         {}
 
@@ -40,8 +40,8 @@ namespace Core
 
     inline AutoConverter Demo()
     {
-        std::tr1::shared_ptr<boost::any> p_result
-            (new boost::any(std::tr1::make_tuple(1, 2, 3, 4)));
+        std::shared_ptr<boost::any> p_result
+            (new boost::any(std::make_tuple(1, 2, 3, 4)));
         return p_result;
     }
 
@@ -50,7 +50,7 @@ namespace Core
 
 int main()
 {
-    std::tr1::tuple<int, int, int, int> test = Core::Demo();
+    std::tuple<int, int, int, int> test = Core::Demo();
     return 0;
 }
 


### PR DESCRIPTION
Now that Boost.TR1 is deprecated and due to be removed, change test to use std:: features instead.  The test should probably be renamed as well I guess...
