### PR TITLE
Avoid unused parameter warning in BOOST_FUSION_DEFINE_STRUCT_INLINE

### DIFF
--- a/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
+++ b/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
@@ -392,9 +392,9 @@
                 typename boost_fusion_detail_It1::index                         \
             >::type type;                                                       \
                                                                                 \
-             BOOST_FUSION_GPU_ENABLED                                           \
-             static type call(boost_fusion_detail_It1 const& it1,               \
-                              boost_fusion_detail_It2 const& it2)               \
+            BOOST_FUSION_GPU_ENABLED                                            \
+            static type call(boost_fusion_detail_It1 const& /* it1 */,          \
+                             boost_fusion_detail_It2 const& /* it2 */)          \
             {                                                                   \
                 return type();                                                  \
             }                                                                   \


### PR DESCRIPTION
Submitting this patch as a pull request, see also https://svn.boost.org/trac/boost/ticket/10679.

Original description:
Expanding the BOOST_FUSION_DEFINE_STRUCT_INLINE macro leads to unused parameter warnings about 'it1' and 'it2', even when the boost include path is marked with -isystem.

The attached patch should avoid the warning.
