### PR TITLE
Fix tickets #10443 completely (SFINAE-friendly invoke).

### DIFF
--- a/include/boost/fusion/functional/invocation/invoke.hpp
+++ b/include/boost/fusion/functional/invocation/invoke.hpp
@@ -52,11 +52,12 @@
 
 namespace boost { namespace fusion
 {
-    namespace result_of
-    {
-        template <typename Function, class Sequence, class Enable = void>
-        struct invoke;
-    }
+    //~ namespace result_of
+    //~ {
+    //~     template <typename Function, class Sequence,
+    //~               class Enable = unspecified>
+    //~     struct invoke;
+    //~ }
 
     //~ template <typename Function, class Sequence>
     //~ inline typename result_of::invoke<Function, Sequence>::type
@@ -71,6 +72,8 @@ namespace boost { namespace fusion
     namespace detail
     {
         namespace ft = function_types;
+
+        template <typename, typename T = void> struct always_void_ { typedef T type; };
 
         template<
             typename Function, class Sequence,
@@ -158,18 +161,14 @@ namespace boost { namespace fusion
 
     namespace result_of
     {
-        template <typename Function, class Sequence, class Enable>
-        struct invoke;
-
-        template <typename Function, class Sequence>
-        struct invoke<Function, Sequence,
-            typename detail::invoke_impl<
-                typename boost::remove_reference<Function>::type, Sequence
-              >::result_type>
+        template <typename Function, class Sequence,
+                  class Enable =
+                    typename detail::invoke_impl<
+                        typename boost::remove_reference<Function>::type, Sequence
+                      >::result_type>
+        struct invoke
         {
-            typedef typename detail::invoke_impl<
-                typename boost::remove_reference<Function>::type, Sequence
-              >::result_type type;
+            typedef Enable type;
         };
     }
 
@@ -208,7 +207,9 @@ namespace boost { namespace fusion
 
         template <typename Function, class Sequence>
         struct invoke_impl<Function,Sequence,N,false,true,
-            typename boost::result_of<Function(BOOST_PP_ENUM(N,M,~)) >::type>
+            typename always_void_<
+                typename boost::result_of<Function(BOOST_PP_ENUM(N,M,~)) >::type
+              >::type>
         {
         public:
 
@@ -299,7 +300,12 @@ namespace boost { namespace fusion
                 fusion::next(BOOST_PP_CAT(i,BOOST_PP_DEC(j)));
 
         template <typename Function, class Sequence>
-        struct invoke_impl<Function,Sequence,N,false,false>
+        struct invoke_impl<Function,Sequence,N,false,false,
+            typename always_void_<
+#define L(z,j,data) typename invoke_param_types<Sequence,N>::BOOST_PP_CAT(T, j)
+                typename boost::result_of<Function(BOOST_PP_ENUM(N,L,~))>::type
+              >::type>
+#undef L
         {
         private:
             typedef invoke_param_types<Sequence,N> seq;


### PR DESCRIPTION
I think @djowel 's fix (6cad6be) is incomplete. I propose a patch to fix completely.

This PR should fix [Test output: BP x86_64 C++11 - fusion - invoke / gcc-4.8.3~c11](http://www.boost.org/development/tests/develop/developer/output/BP%20x86_64%20C++11-boost-bin-v2-libs-fusion-test-invoke-test-gcc-4-8-3~c11-debug-debug-symbols-off.html) and similar failure.

Notes:

```
// A
template <class Func, class A, class Enable = void>
struct invoke_impl;

// B
template <class Func, class A>
struct invoke_impl<Func, A, typename result_of<Func(A)>::type>
{
     typedef typename result_of<Func(A)>::type type;
};

invoke_impl<int(*)(int), int>::type
// This doesn't match expected specialization (B), because result_of::type is `int`
// but `Enable` is `void` (defaulted by template declaration), and compile error.
```

c.f. http://melpon.org/wandbox/permlink/ffr4clbbSgDaWlr2
