### PR TITLE
Improve support for constexpr in fusion::nil and its iterators.

### DIFF
--- a/include/boost/fusion/container/list/cons_iterator.hpp
+++ b/include/boost/fusion/container/list/cons_iterator.hpp
@@ -55,45 +55,45 @@ namespace boost { namespace fusion
         typedef cons_iterator_identity<
             add_const<nil_>::type> 
         identity;
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         nil_iterator() {}
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit nil_iterator(nil_ const&) {}
     };
 
     template <>
     struct cons_iterator<nil_> : nil_iterator 
     {
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         cons_iterator() {}
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit cons_iterator(nil_ const&) {}
     };
 
     template <>
     struct cons_iterator<nil_ const> : nil_iterator 
     {
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         cons_iterator() {}
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit cons_iterator(nil_ const&) {}
     };
 
     template <>
     struct cons_iterator<list<> > : nil_iterator 
     {
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         cons_iterator() {}
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit cons_iterator(nil_ const&) {}
     };
 
     template <>
     struct cons_iterator<list<> const> : nil_iterator 
     {
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         cons_iterator() {}
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit cons_iterator(nil_ const&) {}
     };
 }}

--- a/include/boost/fusion/container/list/nil.hpp
+++ b/include/boost/fusion/container/list/nil.hpp
@@ -31,11 +31,11 @@ namespace boost { namespace fusion
         typedef void_ car_type;
         typedef void_ cdr_type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         nil_() {}
 
         template <typename Iterator>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         nil_(Iterator const& /*iter*/, mpl::true_ /*this_is_an_iterator*/)
         {}
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -97,6 +97,7 @@ project
     [ run sequence/map_move.cpp :  :  :  : ]
     [ run sequence/map_mutate.cpp :  :  :  : ]
     [ run sequence/map_tie.cpp :  :  :  : ]
+    [ run sequence/nil.cpp :  :  :  : ]
     [ run sequence/nview.cpp :  :  :  : ]
     [ run sequence/reverse_view.cpp :  :  :  : ]
     [ run sequence/segmented_iterator_range.cpp : : : : ]

--- a/test/sequence/nil.cpp
+++ b/test/sequence/nil.cpp
@@ -1,0 +1,25 @@
+/*=============================================================================
+    Copyright (c) 2014 Louis Dionne
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/fusion/container/list/cons_iterator.hpp>
+#include <boost/fusion/container/list/nil.hpp>
+#include <boost/fusion/support/config.hpp>
+#include <boost/mpl/bool.hpp>
+
+
+int main() {
+    using namespace boost::fusion;
+
+    // nil should be constexpr constructible
+    {
+        BOOST_CONSTEXPR nil x1 = nil();
+        BOOST_CONSTEXPR nil x2 = nil(nil_iterator(), boost::mpl::true_());
+        (void)x1; (void)x2;
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
`fusion::nil` is a pretty trivial type, and it would be nice to make it constexpr-constructible. The same goes for its iterators. The patch was tested with Apple's clang 6.0.
