### PR TITLE
Fix compile error on MSVC-10 and 11 due to no variadic templates.

### DIFF
--- a/include/boost/fusion/support/detail/result_of.hpp
+++ b/include/boost/fusion/support/detail/result_of.hpp
@@ -8,6 +8,11 @@
 #define FUSION_RESULT_OF_10272014_0654
 
 #include <boost/utility/result_of.hpp>
+#if !(defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES))
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/has_xxx.hpp>
+#endif
 
 namespace boost { namespace fusion { namespace detail
 {
@@ -16,7 +21,7 @@ namespace boost { namespace fusion { namespace detail
     // low level code. So far this is used only in the fold algorithm. This will
     // be removed once we overhaul fold.
 
-#if defined(BOOST_NO_CXX11_DECLTYPE)
+#if defined(BOOST_NO_CXX11_DECLTYPE) || defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
 
     template <typename Sig>
     struct result_of_with_decltype : boost::tr1_result_of<Sig> {};
@@ -31,9 +36,9 @@ namespace boost { namespace fusion { namespace detail
 
     template <typename F, typename... Args>
     struct result_of_with_decltype<F(Args...)>
-        : mpl::if_<mpl::or_<has_result_type<F>, detail::has_result<F>>,
+        : mpl::if_<mpl::or_<has_result_type<F>, detail::has_result<F> >,
             boost::tr1_result_of<F(Args...)>,
-            boost::detail::cpp0x_result_of<F(Args...)>>::type {};
+            boost::detail::cpp0x_result_of<F(Args...)> >::type {};
 
 #endif
 


### PR DESCRIPTION
See Andrey's post on Boost-Devel ML: http://thread.gmane.org/gmane.comp.lib.boost.devel/255086

I can't test under msvc 10/11 now, but I believe that works well.
