### PR TITLE
Use boost::declval instead of std::declval, close #10190.

### DIFF
--- a/include/boost/fusion/container/map/detail/at_impl.hpp
+++ b/include/boost/fusion/container/map/detail/at_impl.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/support/detail/access.hpp>
+#include <boost/utility/declval.hpp>
 
 namespace boost { namespace fusion
 {
@@ -27,7 +28,7 @@ namespace boost { namespace fusion
             {
                 typedef mpl::int_<N::value> index;
                 typedef
-                    decltype(std::declval<Sequence>().get(index()))
+                    decltype(boost::declval<Sequence>().get(index()))
                 type;
 
                 BOOST_FUSION_GPU_ENABLED
@@ -43,7 +44,7 @@ namespace boost { namespace fusion
             {
                 typedef mpl::int_<N::value> index;
                 typedef
-                    decltype(std::declval<Sequence const>().get(index()))
+                    decltype(boost::declval<Sequence const>().get(index()))
                 type;
 
                 BOOST_FUSION_GPU_ENABLED

--- a/include/boost/fusion/container/map/detail/at_key_impl.hpp
+++ b/include/boost/fusion/container/map/detail/at_key_impl.hpp
@@ -12,6 +12,7 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/identity.hpp>
+#include <boost/utility/declval.hpp>
 
 namespace boost { namespace fusion
 {
@@ -29,7 +30,7 @@ namespace boost { namespace fusion
             struct apply
             {
                 typedef
-                    decltype(std::declval<Sequence>().get(mpl::identity<Key>()))
+                    decltype(boost::declval<Sequence>().get(mpl::identity<Key>()))
                 type;
 
                 BOOST_FUSION_GPU_ENABLED
@@ -44,7 +45,7 @@ namespace boost { namespace fusion
             struct apply<Sequence const, Key>
             {
                 typedef
-                    decltype(std::declval<Sequence const>().get(mpl::identity<Key>()))
+                    decltype(boost::declval<Sequence const>().get(mpl::identity<Key>()))
                 type;
 
                 BOOST_FUSION_GPU_ENABLED

--- a/include/boost/fusion/container/map/detail/value_at_impl.hpp
+++ b/include/boost/fusion/container/map/detail/value_at_impl.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/mpl/at.hpp>
+#include <boost/utility/declval.hpp>
 
 namespace boost { namespace fusion
 {
@@ -27,7 +28,7 @@ namespace boost { namespace fusion
             {
                 typedef mpl::int_<N::value> index;
                 typedef
-                    decltype(std::declval<Sequence>().get_val(index()))
+                    decltype(boost::declval<Sequence>().get_val(index()))
                 type;
             };
         };

--- a/include/boost/fusion/container/map/detail/value_at_key_impl.hpp
+++ b/include/boost/fusion/container/map/detail/value_at_key_impl.hpp
@@ -12,6 +12,7 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/identity.hpp>
+#include <boost/utility/declval.hpp>
 
 namespace boost { namespace fusion
 {
@@ -29,7 +30,7 @@ namespace boost { namespace fusion
             struct apply
             {
                 typedef
-                    decltype(std::declval<Sequence>().get_val(mpl::identity<Key>()))
+                    decltype(boost::declval<Sequence>().get_val(mpl::identity<Key>()))
                 type;
             };
         };

--- a/include/boost/fusion/container/map/map_iterator.hpp
+++ b/include/boost/fusion/container/map/map_iterator.hpp
@@ -12,6 +12,7 @@
 #include <boost/fusion/iterator/iterator_facade.hpp>
 #include <boost/mpl/minus.hpp>
 #include <boost/mpl/equal_to.hpp>
+#include <boost/utility/declval.hpp>
 
 namespace boost { namespace fusion
 {
@@ -37,7 +38,7 @@ namespace boost { namespace fusion
             typedef typename Iterator::sequence sequence;
             typedef typename Iterator::index index;
             typedef
-                decltype(std::declval<sequence>().get_val(index()))
+                decltype(boost::declval<sequence>().get_val(index()))
             type;
         };
 
@@ -47,7 +48,7 @@ namespace boost { namespace fusion
             typedef typename Iterator::sequence sequence;
             typedef typename Iterator::index index;
             typedef
-                decltype(std::declval<sequence>().get_val(index()).second)
+                decltype(boost::declval<sequence>().get_val(index()).second)
             type;
         };
 
@@ -56,7 +57,7 @@ namespace boost { namespace fusion
         {
             typedef typename Iterator::sequence sequence;
             typedef typename Iterator::index index;
-            typedef decltype(std::declval<sequence>().get_key(index())) key_identity_type;
+            typedef decltype(boost::declval<sequence>().get_key(index())) key_identity_type;
             typedef typename key_identity_type::type type;
         };
 
@@ -66,7 +67,7 @@ namespace boost { namespace fusion
             typedef typename Iterator::sequence sequence;
             typedef typename Iterator::index index;
             typedef
-                decltype(std::declval<sequence>().get(index()))
+                decltype(boost::declval<sequence>().get(index()))
             type;
 
             BOOST_FUSION_GPU_ENABLED
@@ -83,7 +84,7 @@ namespace boost { namespace fusion
             typedef typename Iterator::sequence sequence;
             typedef typename Iterator::index index;
             typedef
-                decltype(std::declval<sequence>().get(index()).second)
+                decltype(boost::declval<sequence>().get(index()).second)
             type;
 
             BOOST_FUSION_GPU_ENABLED


### PR DESCRIPTION
since GCC 4.4 has no std::declval.
I tested on CentOS6 with GCC 4.4.7.

see https://svn.boost.org/trac/boost/ticket/10190
Thanks-to: Niklas Angare
