### PR TITLE
Fix hard compilation error with nested fusion::cons.

### DIFF
--- a/include/boost/fusion/container/list/cons.hpp
+++ b/include/boost/fusion/container/list/cons.hpp
@@ -27,7 +27,6 @@
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/mpl/int.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/mpl/or.hpp>
 
 namespace boost { namespace fusion
 {
@@ -75,10 +74,7 @@ namespace boost { namespace fusion
         cons(
             Sequence const& seq
           , typename boost::disable_if<
-                mpl::or_<
-                    is_convertible<Sequence, cons> // use copy ctor instead
-                  , is_convertible<Sequence, Car>  // use copy to car instead
-                > 
+                is_convertible<Sequence, Car> // use copy to car instead
             >::type* /*dummy*/ = 0
         )
             : car(*fusion::begin(seq))

--- a/test/sequence/cons.cpp
+++ b/test/sequence/cons.cpp
@@ -16,6 +16,7 @@
 #include <boost/lambda/lambda.hpp>
 #include <boost/fusion/algorithm/iteration/for_each.hpp>
 #include <boost/fusion/algorithm/transformation/filter_if.hpp>
+#include <boost/fusion/algorithm/transformation/push_front.hpp>
 #include <boost/fusion/sequence/io/out.hpp>
 
 #include <boost/type_traits/is_same.hpp>
@@ -81,6 +82,12 @@ main()
         int i = 3;
         cons<int&> tie(cons_tie(i));
         BOOST_TEST((*begin(tie) == 3));
+    }
+
+    {
+        // This used to trigger a hard compilation error:
+        cons<cons<int> > xs;
+        begin(push_front(xs, 3));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
The title pretty much says it all. I was investigating test failures in a project of mine, and I was able to bring it down to a problem in Fusion. See the test case below and the comments on the diff.

I applied the patch on a local master branch and it all passed. However, there are spurious test failures on develop at the time of writing this, so I haven't tested there.
