### PR TITLE
Use BOOST_CONSTEXPR instead of (nonexistant) BOOST_CXX14_CONSTEXPR.

### DIFF
--- a/include/boost/fusion/iterator/basic_iterator.hpp
+++ b/include/boost/fusion/iterator/basic_iterator.hpp
@@ -132,7 +132,7 @@ namespace boost { namespace fusion
         {}
 
         template<typename OtherSeq>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         basic_iterator&
         operator=(basic_iterator<Tag,Category,OtherSeq,Index> const& it)
         {

--- a/include/boost/fusion/sequence/intrinsic/swap.hpp
+++ b/include/boost/fusion/sequence/intrinsic/swap.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion {
             };
 
             template<typename Elem>
-            BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             void operator()(Elem const& e) const
             {
                 using std::swap;
@@ -50,7 +50,7 @@ namespace boost { namespace fusion {
     }
 
     template<typename Seq1, typename Seq2>
-    BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     typename enable_if<mpl::and_<traits::is_sequence<Seq1>, traits::is_sequence<Seq2> >, void>::type
     swap(Seq1& lhs, Seq2& rhs)
     {


### PR DESCRIPTION
All the unit tests on develop pass on Mac OS X with Apple's Clang.
