### PR TITLE
Fix compilation error with as_deque in C++11.

### DIFF
--- a/include/boost/fusion/container/deque/deque.hpp
+++ b/include/boost/fusion/container/deque/deque.hpp
@@ -83,23 +83,29 @@ namespace boost { namespace fusion
         deque()
         {}
 
-        template <typename ...Elements>
+        template <typename Head_, typename ...Tail_, typename =
+            typename enable_if<is_convertible<Head_, Head> >::type
+        >
         BOOST_FUSION_GPU_ENABLED
-        deque(deque<Elements...> const& seq)
+        deque(deque<Head_, Tail_...> const& seq)
           : base(seq)
         {}
 
-        template <typename ...Elements>
+        template <typename Head_, typename ...Tail_, typename =
+            typename enable_if<is_convertible<Head_, Head> >::type
+        >
         BOOST_FUSION_GPU_ENABLED
-        deque(deque<Elements...>& seq)
+        deque(deque<Head_, Tail_...>& seq)
           : base(seq)
         {}
 
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-        template <typename ...Elements>
+        template <typename Head_, typename ...Tail_, typename =
+            typename enable_if<is_convertible<Head_, Head> >::type
+        >
         BOOST_FUSION_GPU_ENABLED
-        deque(deque<Elements...>&& seq)
-          : base(std::forward<deque<Elements...>>(seq))
+        deque(deque<Head_, Tail_...>&& seq)
+          : base(std::forward<deque<Head_, Tail_...>>(seq))
         {}
 #endif
 
@@ -127,7 +133,9 @@ namespace boost { namespace fusion
         {}
 
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-        template <typename Head_, typename ...Tail_>
+        template <typename Head_, typename ...Tail_, typename =
+            typename enable_if<is_convertible<Head_, Head> >::type
+        >
         BOOST_FUSION_GPU_ENABLED
         explicit deque(Head_&& head, Tail_&&... tail)
           : base(detail::deque_keyed_values<Head, Tail...>

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -55,6 +55,7 @@ project
     [ run algorithm/zip_ignore.cpp : : : : ]
     [ run algorithm/flatten.cpp : : : : ]
 
+    [ run sequence/as_deque.cpp :  :  :  : ]
     [ run sequence/as_list.cpp :  :  :  : ]
     [ run sequence/as_map.cpp :  :  :  : ]
     [ run sequence/as_set.cpp :  :  :  : ]

--- a/test/sequence/as_deque.cpp
+++ b/test/sequence/as_deque.cpp
@@ -1,0 +1,60 @@
+/*=============================================================================
+    Copyright (c) 2014 Louis Dionne
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/fusion/algorithm/transformation/push_back.hpp>
+#include <boost/fusion/algorithm/transformation/push_front.hpp>
+#include <boost/fusion/container/deque/convert.hpp>
+#include <boost/fusion/container/deque/deque.hpp>
+#include <boost/fusion/container/generation/make_deque.hpp>
+#include <boost/fusion/container/generation/make_list.hpp>
+#include <boost/fusion/container/generation/make_vector.hpp>
+#include <boost/fusion/sequence/comparison/equal_to.hpp>
+
+#include <string>
+
+
+int main() {
+    using namespace boost::fusion;
+    using namespace boost;
+
+    BOOST_TEST(as_deque(make_vector()) == make_deque());
+    BOOST_TEST(as_deque(make_vector(1)) == make_deque(1));
+    BOOST_TEST(as_deque(make_vector(1, '2')) == make_deque(1, '2'));
+    BOOST_TEST(as_deque(make_vector(1, '2', 3.3f)) == make_deque(1, '2', 3.3f));
+
+    BOOST_TEST(as_deque(make_list()) == make_deque());
+    BOOST_TEST(as_deque(make_list(1)) == make_deque(1));
+    BOOST_TEST(as_deque(make_list(1, '2')) == make_deque(1, '2'));
+    BOOST_TEST(as_deque(make_list(1, '2', 3.3f)) == make_deque(1, '2', 3.3f));
+
+    {
+        deque<> xs;
+        BOOST_TEST(as_deque(push_back(xs, 1)) == make_deque(1));
+    }
+
+    {
+        deque<int> xs(1);
+        BOOST_TEST(as_deque(push_back(xs, '2')) == make_deque(1, '2'));
+    }
+
+    {
+        deque<int, char> xs(1, '2');
+        BOOST_TEST(as_deque(push_back(xs, 3.3f)) == make_deque(1, '2', 3.3f));
+    }
+
+    {
+        deque<> xs;
+        BOOST_TEST(
+            as_deque(push_front(xs, make_deque(1, '2', 3.3f))) ==
+            make_deque(make_deque(1, '2', 3.3f))
+        );
+
+        BOOST_TEST(as_deque(make_deque(make_deque(1))) == make_deque(make_deque(1)));
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
In C++11, `as_deque` did not compile for even simple use cases. I added a unit test and a fix (which is not 100% clean, see inline comments). With the patch applied, all the unit tests are passing on develop with Apple's Clang and -std=c++1y.
