### PR TITLE
result_of::size::value and result_of::size::type::value should be same type

### DIFF
--- a/include/boost/fusion/sequence/intrinsic/size.hpp
+++ b/include/boost/fusion/sequence/intrinsic/size.hpp
@@ -49,10 +49,10 @@ namespace boost { namespace fusion
             template <typename Sequence>
             struct apply : Sequence::template size<Sequence> {};
         };
- 
+
         template <>
         struct size_impl<boost_tuple_tag>;
- 
+
         template <>
         struct size_impl<boost_array_tag>;
 
@@ -67,14 +67,10 @@ namespace boost { namespace fusion
     {
         template <typename Sequence>
         struct size
-            : extension::size_impl<typename detail::tag_of<Sequence>::type>::
-        template apply<Sequence>
-
-        {
-            typedef typename extension::size_impl<typename detail::tag_of<Sequence>::type>::
-            template apply<Sequence>::type size_application;
-            BOOST_STATIC_CONSTANT(int, value = size_application::value);
-        };
+            : mpl::int_<
+                  extension::size_impl<typename detail::tag_of<Sequence>::type>
+                      ::template apply<Sequence>::type::value
+              > {};
     }
 
     template <typename Sequence>

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -161,6 +161,8 @@ project
     [ run sequence/ref_vector.cpp : : : : ]
     [ run sequence/flatten_view.cpp : : : : ]
 
+    [ compile sequence/size.cpp : : : : ]
+
     [ run functional/fused.cpp : : : : ]
     [ run functional/fused_function_object.cpp : : : : ]
     [ run functional/fused_procedure.cpp : : : : ]

--- a/test/sequence/size.cpp
+++ b/test/sequence/size.cpp
@@ -1,0 +1,101 @@
+/*=============================================================================
+    Copyright (c) 2014 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/config.hpp>
+#include <boost/fusion/container/vector.hpp>
+#include <boost/fusion/container/deque.hpp>
+#include <boost/fusion/container/list.hpp>
+#include <boost/fusion/container/set.hpp>
+#include <boost/fusion/container/map.hpp>
+#include <boost/fusion/support/pair.hpp>
+#include <boost/fusion/sequence/intrinsic/size.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/assert.hpp>
+
+#include <boost/array.hpp>
+#include <boost/fusion/adapted/boost_array.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/fusion/adapted/boost_tuple.hpp>
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+#include <tuple>
+#include <boost/fusion/adapted/std_tuple.hpp>
+#endif
+
+template <typename LHS, typename RHS>
+void check_(LHS const&, RHS const&)
+{
+    BOOST_MPL_ASSERT((boost::is_same<LHS, RHS>));
+}
+
+template <typename S>
+void check()
+{
+    check_(
+        boost::fusion::result_of::size<S>::type::value
+      , boost::fusion::result_of::size<S>::value
+    );
+}
+
+void test()
+{
+    {
+        check<boost::fusion::vector<> >();
+        check<boost::fusion::vector<int> >();
+        check<boost::fusion::vector<int, int> >();
+        check<boost::fusion::vector<int, int, int> >();
+    }
+
+    {
+        check<boost::fusion::deque<> >();
+        check<boost::fusion::deque<int> >();
+        check<boost::fusion::deque<int, int> >();
+        check<boost::fusion::deque<int, int, int> >();
+    }
+
+    {
+        check<boost::fusion::list<> >();
+        check<boost::fusion::list<int> >();
+        check<boost::fusion::list<int, int> >();
+        check<boost::fusion::list<int, int, int> >();
+    }
+
+    {
+        check<boost::fusion::set<> >();
+        check<boost::fusion::set<int> >();
+        check<boost::fusion::set<int, float> >();
+        check<boost::fusion::set<int, float, double> >();
+    }
+
+    {
+        check<boost::fusion::map<> >();
+        check<boost::fusion::map<boost::fusion::pair<int, int> > >();
+        check<boost::fusion::map<boost::fusion::pair<int, int> , boost::fusion::pair<float, int> > >();
+        check<boost::fusion::map<boost::fusion::pair<int, int> , boost::fusion::pair<float, int> , boost::fusion::pair<double, int> > >();
+    }
+
+    {
+        check<boost::array<int, 1> >();
+        check<boost::array<int, 2> >();
+        check<boost::array<int, 3> >();
+    }
+
+    {
+        check<boost::tuples::tuple<> >();
+        check<boost::tuples::tuple<int> >();
+        check<boost::tuples::tuple<int, int> >();
+        check<boost::tuples::tuple<int, int, int> >();
+    }
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+    {
+        check<std::tuple<> >();
+        check<std::tuple<int> >();
+        check<std::tuple<int, int> >();
+        check<std::tuple<int, int, int> >();
+    }
+#endif
+}
+


### PR DESCRIPTION
Split up from #39 

Fix metafunction type mismatch, which is described in [#7304](https://svn.boost.org/trac/boost/ticket/7304). However, still stay on wontfix status.
e.g. In C++03 mode, `result_of::size<deque<...> >::value` has `int`, but `result_of::size<deque<...> >::type::value_type` has `long`.
