### PR TITLE
Fix two major MSVC issues.

### DIFF
--- a/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
@@ -141,7 +141,10 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
             {}
         template<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, typename U)>
         BOOST_FUSION_GPU_ENABLED
-        deque(deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>&& seq)
+        deque(deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>&& seq
+            , typename disable_if<
+                  is_convertible<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>, T0>
+              >::type* /*dummy*/ = 0)
             : base(std::forward<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>>(seq))
             {}
         template <typename T>

--- a/include/boost/fusion/container/deque/detail/keyed_element.hpp
+++ b/include/boost/fusion/container/deque/detail/keyed_element.hpp
@@ -66,7 +66,8 @@ namespace boost { namespace fusion { namespace detail
 
         template <typename U, typename Rst>
         BOOST_FUSION_GPU_ENABLED
-        keyed_element(keyed_element<Key, U, Rst> const& rhs)
+        keyed_element(keyed_element<Key, U, Rst> const& rhs
+          , typename enable_if<is_convertible<U, Value> >::type* = 0)
           : Rest(rhs.get_base()), value_(rhs.value_)
         {}
 

--- a/include/boost/fusion/container/map/detail/cpp03/map.hpp
+++ b/include/boost/fusion/container/map/detail/cpp03/map.hpp
@@ -24,6 +24,15 @@
 #include <boost/fusion/container/vector/vector.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/bool.hpp>
+#include <boost/preprocessor/iterate.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
+    defined(BOOST_MSVC) && (BOOST_MSVC == 1700)
+// see map_forward_ctor.hpp
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_same.hpp>
+#endif
 
 #if !defined(BOOST_FUSION_DONT_USE_PREPROCESSED_FILES)
 #include <boost/fusion/container/map/detail/cpp03/preprocessed/map.hpp>
@@ -44,6 +53,8 @@
 #if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
 #pragma wave option(preserve: 1)
 #endif
+
+#define FUSION_HASH #
 
 namespace boost { namespace fusion
 {
@@ -69,6 +80,10 @@ namespace boost { namespace fusion
         map()
             : data() {}
 
+        BOOST_FUSION_GPU_ENABLED
+        map(map const& rhs)
+            : data(rhs.data) {}
+
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence const& rhs)
@@ -91,6 +106,34 @@ namespace boost { namespace fusion
             return *this;
         }
 
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#endif
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || \
+    (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
+        BOOST_FUSION_GPU_ENABLED
+        map(map&& rhs)
+            : data(std::move(rhs.data)) {}
+
+        template <typename T>
+        BOOST_FUSION_GPU_ENABLED
+        map& operator=(T&& rhs)
+        {
+            data = BOOST_FUSION_FWD_ELEM(T, rhs);
+            return *this;
+        }
+
+        BOOST_FUSION_GPU_ENABLED
+        map& operator=(map&& rhs)
+        {
+            data = std::move(rhs.data);
+            return *this;
+        }
+#endif
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH endif
+#endif
+
         BOOST_FUSION_GPU_ENABLED
         storage_type& get_data() { return data; }
         BOOST_FUSION_GPU_ENABLED
@@ -101,6 +144,8 @@ namespace boost { namespace fusion
         storage_type data;
     };
 }}
+
+#undef FUSION_HASH
 
 #if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
 #pragma wave option(output: null)

--- a/include/boost/fusion/container/map/detail/cpp03/map_forward_ctor.hpp
+++ b/include/boost/fusion/container/map/detail/cpp03/map_forward_ctor.hpp
@@ -8,15 +8,14 @@
 #if !defined(FUSION_MAP_FORWARD_CTOR_07222005_0106)
 #define FUSION_MAP_FORWARD_CTOR_07222005_0106
 
-#include <boost/preprocessor/iterate.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
-#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#define FUSION_FORWARD_CTOR_FORWARD(z, n, _)    BOOST_FUSION_FWD_ELEM(U##n, _##n)
 
 #define BOOST_PP_FILENAME_1 \
     <boost/fusion/container/map/detail/cpp03/map_forward_ctor.hpp>
 #define BOOST_PP_ITERATION_LIMITS (1, FUSION_MAX_MAP_SIZE)
 #include BOOST_PP_ITERATE()
 
+#undef FUSION_FORWARD_CTOR_FORWARD
 #endif
 #else // defined(BOOST_PP_IS_ITERATING)
 ///////////////////////////////////////////////////////////////////////////////
@@ -33,6 +32,31 @@
 #endif
     map(BOOST_PP_ENUM_BINARY_PARAMS(N, typename detail::call_param<T, >::type arg))
         : data(BOOST_PP_ENUM_PARAMS(N, arg)) {}
+
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#endif
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || \
+    (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
+    template <BOOST_PP_ENUM_PARAMS(N, typename U)>
+    BOOST_FUSION_GPU_ENABLED
+#if N == 1
+    explicit
+#endif
+    map(BOOST_PP_ENUM_BINARY_PARAMS(N, U, && arg)
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES) && \
+    N == 1
+    // workaround for MSVC 10
+FUSION_HASH if defined(BOOST_MSVC) && (BOOST_MSVC == 1700)
+        , typename enable_if<is_same<U0, T0> >::type* = 0
+FUSION_HASH endif
+#endif
+        )
+        : data(BOOST_PP_ENUM(N, FUSION_FORWARD_CTOR_FORWARD, arg)) {}
+#endif
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH endif
+#endif
 
 #undef N
 #endif // defined(BOOST_PP_IS_ITERATING)

--- a/test/sequence/size.cpp
+++ b/test/sequence/size.cpp
@@ -19,7 +19,8 @@
 #include <boost/fusion/adapted/boost_array.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/fusion/adapted/boost_tuple.hpp>
-#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE) && \
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
 #include <tuple>
 #include <boost/fusion/adapted/std_tuple.hpp>
 #endif
@@ -89,7 +90,8 @@ void test()
         check<boost::tuples::tuple<int, int, int> >();
     }
 
-#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE) && \
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     {
         check<std::tuple<> >();
         check<std::tuple<int> >();

--- a/test/sequence/std_tuple_iterator.cpp
+++ b/test/sequence/std_tuple_iterator.cpp
@@ -8,7 +8,8 @@
 
 // The std_tuple_iterator adaptor only supports implementations
 // using variadic templates
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE) && \
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
 
 #include <boost/fusion/adapted/std_tuple.hpp>
 


### PR DESCRIPTION
Those commits will fix two test case failures: [as_deque / msvc](http://www.boost.org/development/tests/develop/developer/output/teeks99-08e-win2012R2-64on64-boost-bin-v2-libs-fusion-test-as_deque-test-msvc-12-0-debug-threading-multi.html) and [map_move / msvc](http://www.boost.org/development/tests/develop/developer/output/teeks99-08e-win2012R2-64on64-boost-bin-v2-libs-fusion-test-map_move-test-msvc-12-0-debug-threading-multi.html).

Tested under:
- MSVC 9.0(2008) / 10.0(2010) / 11.0(2012u4) / 12.0(2013u4) / 14.0(2015 Preview)
- GCC 4.9.2 C++03 / C++11 / C++1y
- LLVM Clang 3.5.0 C++03 / C++11 / C++1y

Note: (Re)generating preprocessed file is required.

Blocks: #48 