### PR TITLE
Support removing the C++11 standard reference wrappers.

### DIFF
--- a/doc/notes.qbk
+++ b/doc/notes.qbk
@@ -121,7 +121,7 @@ creates a __list__ of type
 
     __list__<void (*)(int)>
 
-[heading boost::ref]
+[heading Reference Wrappers]
 
 Fusion's generation functions (e.g. __make_list__) by default stores the
 element types as plain non-reference types. Example:
@@ -150,6 +150,8 @@ For example:
     __make_list__(ref(ca));             // creates list<const A&>
 
 See __boost_ref__ for details.
+
+Since C++11, the standard reference wrappers (`std::ref` and `std::cref`) work as well.
 
 [heading adt_attribute_proxy]
 

--- a/doc/support.qbk
+++ b/doc/support.qbk
@@ -254,7 +254,8 @@ Metafunction to apply __element_conversion__ to the full argument type.
 
 It removes references to `const`, references to array types are kept, even
 if the array is `const`. Reference wrappers are removed (see
-__note_boost_ref__).
+__note_boost_ref__)[footnote Since C++11, the standard reference wrappers
+are also removed.].
 
 [heading Header]
 

--- a/include/boost/fusion/algorithm/auxiliary.hpp
+++ b/include/boost/fusion/algorithm/auxiliary.hpp
@@ -9,5 +9,6 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/algorithm/auxiliary/copy.hpp>
+#include <boost/fusion/algorithm/auxiliary/move.hpp>
 
 #endif

--- a/include/boost/fusion/support/deduce.hpp
+++ b/include/boost/fusion/support/deduce.hpp
@@ -12,6 +12,10 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/ref.hpp>
 
+#ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
+#include <functional>
+#endif
+
 namespace boost { namespace fusion { namespace traits
 {
     template <typename T> struct deduce;
@@ -85,6 +89,21 @@ namespace boost { namespace fusion { namespace traits
     {
         typedef T& type;
     };
+
+    // Also unwrap C++11 std::ref if available (referencee cv is deduced)
+#ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
+    template <typename T>
+    struct deduce<std::reference_wrapper<T> &>
+    {
+        typedef T& type;
+    };
+
+    template <typename T>
+    struct deduce<std::reference_wrapper<T> const &>
+    {
+        typedef T& type;
+    };
+#endif
 
     // Keep references on arrays, even if const
 

--- a/include/boost/fusion/support/detail/as_fusion_element.hpp
+++ b/include/boost/fusion/support/detail/as_fusion_element.hpp
@@ -11,6 +11,10 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/ref.hpp>
 
+#ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
+#include <functional>
+#endif
+
 namespace boost { namespace fusion { namespace detail
 {
     template <typename T>
@@ -24,6 +28,14 @@ namespace boost { namespace fusion { namespace detail
     {
         typedef T& type;
     };
+
+#ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
+    template <typename T>
+    struct as_fusion_element<std::reference_wrapper<T> >
+    {
+        typedef T& type;
+    };
+#endif
 
     template <typename T, int N>
     struct as_fusion_element<T[N]>

--- a/test/algorithm/pop_back.cpp
+++ b/test/algorithm/pop_back.cpp
@@ -95,7 +95,7 @@ main()
 #endif
 
     {
-        boost::array<std::size_t, 2> a = { 10, 50 };
+        boost::array<std::size_t, 2> a = {{ 10, 50 }};
         BOOST_TEST(back(pop_back(a)) == 10);
     }
 

--- a/test/functional/invoke.cpp
+++ b/test/functional/invoke.cpp
@@ -7,6 +7,7 @@
     http://www.boost.org/LICENSE_1_0.txt).
 ==============================================================================*/
 
+#include <boost/config.hpp>
 #include <boost/fusion/functional/invocation/invoke.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -146,10 +147,27 @@ class members
     int binary_c(int i, object) const { return data + 6 + i; }
 };
 
+#ifdef BOOST_NO_CXX11_SMART_PTR
+typedef std::auto_ptr<members      >       members_ptr;
+typedef std::auto_ptr<members const> const_members_ptr;
+#else
+typedef std::unique_ptr<members      >       members_ptr;
+typedef std::unique_ptr<members const> const_members_ptr;
+#endif
+
 struct derived
     : members
 {
 };
+
+#ifdef BOOST_NO_CXX11_SMART_PTR
+typedef std::auto_ptr<derived      >       derived_ptr;
+typedef std::auto_ptr<derived const> const_derived_ptr;
+#else
+typedef std::unique_ptr<derived      >       derived_ptr;
+typedef std::unique_ptr<derived const> const_derived_ptr;
+#endif
+
 
 typedef int         element1_type;
 typedef object      element2_type;
@@ -161,8 +179,8 @@ object_nc   element3;
 
 members that;
 
-std::auto_ptr<members> spt_that(new members);
-std::auto_ptr<members const> spt_that_c(new members);
+members_ptr spt_that(new members);
+const_members_ptr spt_that_c(new members);
 
 fusion::single_view<members  > sv_obj_ctx(  that);
 fusion::single_view<members &> sv_ref_ctx(  that);
@@ -170,13 +188,13 @@ fusion::single_view<members *> sv_ptr_ctx(& that);
 fusion::single_view<members const  > sv_obj_c_ctx(  that);
 fusion::single_view<members const &> sv_ref_c_ctx(  that);
 fusion::single_view<members const *> sv_ptr_c_ctx(& that);
-fusion::single_view<std::auto_ptr<members> const &> sv_spt_ctx(spt_that);
-fusion::single_view< std::auto_ptr<members const> const &> sv_spt_c_ctx(spt_that_c);
+fusion::single_view<members_ptr const &> sv_spt_ctx(spt_that);
+fusion::single_view<const_members_ptr const &> sv_spt_c_ctx(spt_that_c);
 
 derived derived_that;
 
-std::auto_ptr<derived> spt_derived_that(new derived);
-std::auto_ptr<derived const> spt_derived_that_c(new derived);
+derived_ptr spt_derived_that(new derived);
+const_derived_ptr spt_derived_that_c(new derived);
 
 fusion::single_view<derived  > sv_obj_d_ctx(  derived_that);
 fusion::single_view<derived &> sv_ref_d_ctx(  derived_that);
@@ -184,8 +202,8 @@ fusion::single_view<derived *> sv_ptr_d_ctx(& derived_that);
 fusion::single_view<derived const  > sv_obj_c_d_ctx(  derived_that);
 fusion::single_view<derived const &> sv_ref_c_d_ctx(  derived_that);
 fusion::single_view<derived const *> sv_ptr_c_d_ctx(& derived_that);
-fusion::single_view<std::auto_ptr<derived> const &> sv_spt_d_ctx(spt_derived_that);
-fusion::single_view< std::auto_ptr<derived const> const &> sv_spt_c_d_ctx(spt_derived_that_c);
+fusion::single_view<derived_ptr const &> sv_spt_d_ctx(spt_derived_that);
+fusion::single_view<const_derived_ptr const &> sv_spt_c_d_ctx(spt_derived_that_c);
 
 template <class Sequence>
 void test_sequence_n(Sequence & seq, mpl::int_<0>)

--- a/test/functional/invoke_procedure.cpp
+++ b/test/functional/invoke_procedure.cpp
@@ -7,6 +7,7 @@
     http://www.boost.org/LICENSE_1_0.txt).
 ==============================================================================*/
 
+#include <boost/config.hpp>
 #include <boost/fusion/functional/invocation/invoke_procedure.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
@@ -65,9 +66,17 @@ class members
     int binary_c(int & i, object) const { return i = data + 6; }
 };
 
+#ifdef BOOST_NO_CXX11_SMART_PTR
+typedef std::auto_ptr<members      >       members_ptr;
+typedef std::auto_ptr<members const> const_members_ptr;
+#else
+typedef std::unique_ptr<members      >       members_ptr;
+typedef std::unique_ptr<members const> const_members_ptr;
+#endif
+
 members that;
-std::auto_ptr<members> spt_that(new members);
-std::auto_ptr<members const> spt_that_c(new members);
+members_ptr spt_that(new members);
+const_members_ptr spt_that_c(new members);
 
 fusion::single_view<members  > sv_obj_ctx(  that);
 fusion::single_view<members &> sv_ref_ctx(  that);
@@ -75,8 +84,8 @@ fusion::single_view<members *> sv_ptr_ctx(& that);
 fusion::single_view<members const  > sv_obj_c_ctx(  that);
 fusion::single_view<members const &> sv_ref_c_ctx(  that);
 fusion::single_view<members const *> sv_ptr_c_ctx(& that);
-fusion::single_view<std::auto_ptr<members> const &> sv_spt_ctx(spt_that);
-fusion::single_view< std::auto_ptr<members const> const &> sv_spt_c_ctx(spt_that_c);
+fusion::single_view<members_ptr const &> sv_spt_ctx(spt_that);
+fusion::single_view<const_members_ptr const &> sv_spt_c_ctx(spt_that_c);
 
 struct fobj
 {

--- a/test/sequence/adapt_struct.cpp
+++ b/test/sequence/adapt_struct.cpp
@@ -178,7 +178,7 @@ main()
 
     {
         fusion::vector<int, float> v1(4, 2);
-        ns::bar v2 = {5, 3};
+        ns::bar v2 = {{5}, 3};
         BOOST_TEST(v1 < v2);
         BOOST_TEST(v1 <= v2);
         BOOST_TEST(v2 > v1);

--- a/test/sequence/deduce_sequence.cpp
+++ b/test/sequence/deduce_sequence.cpp
@@ -6,6 +6,7 @@
     http://www.boost.org/LICENSE_1_0.txt).
 ==============================================================================*/
 
+#include <boost/config.hpp>
 #include <boost/fusion/support/deduce_sequence.hpp>
 #include <boost/fusion/mpl.hpp>
 #include <boost/detail/lightweight_test.hpp>
@@ -13,6 +14,9 @@
 #include <boost/mpl/equal.hpp>
 
 #include <boost/ref.hpp>
+#ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
+#include <functional>
+#endif
 
 using boost::is_same;
 using boost::reference_wrapper;
@@ -65,6 +69,13 @@ int main()
     TEST_SAME_TYPE(deduce< reference_wrapper<int const> & >::type, int const &);
     TEST_SAME_TYPE(deduce< reference_wrapper<int> const & >::type, int &);
     TEST_SAME_TYPE(deduce< reference_wrapper<int const> const & >::type, int const &);
+
+#ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
+    TEST_SAME_TYPE(deduce< std::reference_wrapper<int> & >::type, int &);
+    TEST_SAME_TYPE(deduce< std::reference_wrapper<int const> & >::type, int const &);
+    TEST_SAME_TYPE(deduce< std::reference_wrapper<int> const & >::type, int &);
+    TEST_SAME_TYPE(deduce< std::reference_wrapper<int const> const & >::type, int const &);
+#endif
 
     TEST_SAME_TYPE(deduce< int(&)[2] >::type, int(&)[2]);
     TEST_SAME_TYPE(deduce< int const (&)[2] >::type, int const (&)[2]);

--- a/test/sequence/move.hpp
+++ b/test/sequence/move.hpp
@@ -38,12 +38,12 @@ namespace test_detail
             return *this;
         }
 
-        x(x const& rhs)
+        x(x const& /*rhs*/)
         {
             incr_copy();
         }
 
-        x& operator=(x const& rhs)
+        x& operator=(x const& /*rhs*/)
         {
             incr_copy();
             return *this;


### PR DESCRIPTION
This PR lets Fusion treat std::reference_wrapper as same as Boost.Ref.

Tested under:
- MSVC 9.0(2008) / 10.0(2010) / 11.0(2012u4) / 12.0(2013u4) / 14.0(2015 Preview)
- GCC 4.9.2 C++03 / C++11 / C++1y
- LLVM Clang 3.5.0 C++03 / C++11 / C++1y
