### PR TITLE
Workaround for LWG 2408: SFINAE-friendly std::iterator_traits.

### DIFF
--- a/include/boost/fusion/adapted/boost_array/array_iterator.hpp
+++ b/include/boost/fusion/adapted/boost_array/array_iterator.hpp
@@ -109,4 +109,13 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Array, int Pos>
+    struct iterator_traits< ::boost::fusion::array_iterator<Array, Pos> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/adapted/boost_tuple/boost_tuple_iterator.hpp
+++ b/include/boost/fusion/adapted/boost_tuple/boost_tuple_iterator.hpp
@@ -207,6 +207,15 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Cons>
+    struct iterator_traits< ::boost::fusion::boost_tuple_iterator<Cons> >
+    { };
+}
+#endif
+
 #endif
 
 

--- a/include/boost/fusion/adapted/mpl/mpl_iterator.hpp
+++ b/include/boost/fusion/adapted/mpl/mpl_iterator.hpp
@@ -114,6 +114,15 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Iterator>
+    struct iterator_traits< ::boost::fusion::mpl_iterator<Iterator> >
+    { };
+}
+#endif
+
 #endif
 
 

--- a/include/boost/fusion/adapted/std_tuple/std_tuple_iterator.hpp
+++ b/include/boost/fusion/adapted/std_tuple/std_tuple_iterator.hpp
@@ -106,6 +106,15 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Tuple, int Index>
+    struct iterator_traits< ::boost::fusion::std_tuple_iterator<Tuple, Index> >
+    { };
+}
+#endif
+
 #endif
 
 

--- a/include/boost/fusion/container/deque/deque_iterator.hpp
+++ b/include/boost/fusion/container/deque/deque_iterator.hpp
@@ -118,4 +118,13 @@ namespace boost { namespace fusion {
 
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Seq, int Pos>
+    struct iterator_traits< ::boost::fusion::deque_iterator<Seq, Pos> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/container/list/cons_iterator.hpp
+++ b/include/boost/fusion/container/list/cons_iterator.hpp
@@ -98,4 +98,13 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Cons>
+    struct iterator_traits< ::boost::fusion::cons_iterator<Cons> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/container/map/map_iterator.hpp
+++ b/include/boost/fusion/container/map/map_iterator.hpp
@@ -163,4 +163,13 @@ namespace boost { namespace fusion
 
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Seq, int Pos>
+    struct iterator_traits< ::boost::fusion::map_iterator<Seq, Pos> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/container/vector/vector_iterator.hpp
+++ b/include/boost/fusion/container/vector/vector_iterator.hpp
@@ -48,5 +48,14 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Vector, int N>
+    struct iterator_traits< ::boost::fusion::vector_iterator<Vector, N> >
+    { };
+}
+#endif
+
 #endif
 

--- a/include/boost/fusion/iterator/basic_iterator.hpp
+++ b/include/boost/fusion/iterator/basic_iterator.hpp
@@ -144,4 +144,13 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Tag, typename Category, typename Seq, int Index>
+    struct iterator_traits< ::boost::fusion::basic_iterator<Tag, Category, Seq, Index> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/iterator/iterator_adapter.hpp
+++ b/include/boost/fusion/iterator/iterator_adapter.hpp
@@ -135,4 +135,13 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Derived, typename Iterator, typename Category>
+    struct iterator_traits< ::boost::fusion::iterator_adapter<Derived, Iterator, Category> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/iterator/iterator_facade.hpp
+++ b/include/boost/fusion/iterator/iterator_facade.hpp
@@ -56,4 +56,13 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Derived, typename Category>
+    struct iterator_traits< ::boost::fusion::iterator_facade<Derived, Category> >
+    { };
+}
+#endif
+
 #endif

--- a/include/boost/fusion/support/config.hpp
+++ b/include/boost/fusion/support/config.hpp
@@ -68,4 +68,23 @@ namespace boost { namespace fusion { namespace detail
 #   define BOOST_FUSION_FWD_ELEM(type, value) std::forward<type>(value)
 #endif
 
+
+// Workaround for LWG 2408: C++17 SFINAE-friendly std::iterator_traits.
+// http://cplusplus.github.io/LWG/lwg-defects.html#2408
+//
+// - GCC 4.5 enables the feature under C++11.
+//   https://gcc.gnu.org/ml/gcc-patches/2014-11/msg01105.html
+//
+// - Only MSVC 12.0 doesn't have the feature.
+#if (defined(BOOST_LIBSTDCXX_VERSION) && (BOOST_LIBSTDCXX_VERSION < 40500) && \
+     defined(BOOST_LIBSTDCXX11)) || \
+    (defined(BOOST_MSVC) && (BOOST_MSVC == 1800))
+#   define BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename>
+    struct iterator_traits;
+}
+#endif
+
 #endif

--- a/include/boost/fusion/view/filter_view/filter_view_iterator.hpp
+++ b/include/boost/fusion/view/filter_view/filter_view_iterator.hpp
@@ -67,6 +67,15 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Category, typename First, typename Last, typename Pred>
+    struct iterator_traits< ::boost::fusion::filter_iterator<Category, First, Last, Pred> >
+    { };
+}
+#endif
+
 #endif
 
 

--- a/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
@@ -194,6 +194,15 @@ namespace boost { namespace fusion { namespace extension
     };
 }}}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename First, typename Base>
+    struct iterator_traits< ::boost::fusion::flatten_view_iterator<First, Base> >
+    { };
+}
+#endif
+
 
 #endif
 

--- a/include/boost/fusion/view/joint_view/joint_view_iterator.hpp
+++ b/include/boost/fusion/view/joint_view/joint_view_iterator.hpp
@@ -56,6 +56,15 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Category, typename First, typename Last, typename Concat>
+    struct iterator_traits< ::boost::fusion::joint_view_iterator<Category, First, Last, Concat> >
+    { };
+}
+#endif
+
 #endif
 
 

--- a/include/boost/fusion/view/nview/nview_iterator.hpp
+++ b/include/boost/fusion/view/nview/nview_iterator.hpp
@@ -54,6 +54,15 @@ namespace boost { namespace fusion
 
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Sequence, typename Pos>
+    struct iterator_traits< ::boost::fusion::nview_iterator<Sequence, Pos> >
+    { };
+}
+#endif
+
 #endif
 
 

--- a/include/boost/fusion/view/repetitive_view/repetitive_view_iterator.hpp
+++ b/include/boost/fusion/view/repetitive_view/repetitive_view_iterator.hpp
@@ -53,5 +53,14 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename Sequence, typename Pos>
+    struct iterator_traits< ::boost::fusion::repetitive_view_iterator<Sequence, Pos> >
+    { };
+}
+#endif
+
 #endif
 

--- a/include/boost/fusion/view/reverse_view/reverse_view_iterator.hpp
+++ b/include/boost/fusion/view/reverse_view/reverse_view_iterator.hpp
@@ -54,5 +54,14 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename First>
+    struct iterator_traits< ::boost::fusion::reverse_view_iterator<First> >
+    { };
+}
+#endif
+
 #endif
 

--- a/include/boost/fusion/view/single_view/single_view_iterator.hpp
+++ b/include/boost/fusion/view/single_view/single_view_iterator.hpp
@@ -50,6 +50,15 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename SingleView, typename Pos>
+    struct iterator_traits< ::boost::fusion::single_view_iterator<SingleView, Pos> >
+    { };
+}
+#endif
+
 #if defined (BOOST_MSVC)
 #  pragma warning(pop)
 #endif

--- a/include/boost/fusion/view/transform_view/transform_view_iterator.hpp
+++ b/include/boost/fusion/view/transform_view/transform_view_iterator.hpp
@@ -76,5 +76,17 @@ namespace boost { namespace fusion
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename First, typename F>
+    struct iterator_traits< ::boost::fusion::transform_view_iterator<First, F> >
+    { };
+    template <typename First1, typename First2, typename F>
+    struct iterator_traits< ::boost::fusion::transform_view_iterator2<First1, First2, F> >
+    { };
+}
+#endif
+
 #endif
 

--- a/include/boost/fusion/view/zip_view/zip_view_iterator.hpp
+++ b/include/boost/fusion/view/zip_view/zip_view_iterator.hpp
@@ -46,4 +46,13 @@ namespace boost { namespace fusion {
     };
 }}
 
+#ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
+namespace std
+{
+    template <typename IteratorSequence, typename Traversal>
+    struct iterator_traits< ::boost::fusion::zip_view_iterator<IteratorSequence, Traversal> >
+    { };
+}
+#endif
+
 #endif


### PR DESCRIPTION
Fix [std_tuple_iterator / msvc-12.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08e-win2012R2-64on64-boost-bin-v2-libs-fusion-test-std_tuple_iterator-test-msvc-12-0-debug-threading-multi.html) and [std_tuple_iterator / gcc-4.4.7](http://www.boost.org/development/tests/develop/developer/output/Sandia-gcc-4-4-7-c++0x-boost-bin-v2-libs-fusion-test-std_tuple_iterator-test-gcc-4-4-7-debug.html).

SFINAE-friendly std::iterator_traits is now available for GCC(libstdc++v3) < 4.5 and MSVC 12.0. It means, there is no ambiguous about calling next/prior/... via ADL.

- Tested:
 * MSVC 9.0(2008) / 10.0(2010) / 11.0(2012u4) / 12.0(2013u4) / 14.0(2015 Preview)
 * GCC 4.9.2 C++03 / C++11 / C++1y
 * LLVM Clang 3.5.0 C++03 / C++11 / C++14
