### PR TITLE
Fix workaround condition: || v.s. &&.

### DIFF
--- a/include/boost/fusion/support/config.hpp
+++ b/include/boost/fusion/support/config.hpp
@@ -79,7 +79,7 @@ namespace boost { namespace fusion { namespace detail
 // - MSVC 10.0 implements iterator intrinsics; MSVC 13.0 implements LWG2408.
 #if (defined(BOOST_LIBSTDCXX_VERSION) && (BOOST_LIBSTDCXX_VERSION < 40500) && \
      defined(BOOST_LIBSTDCXX11)) || \
-    (defined(BOOST_MSVC) && (1600 <= BOOST_MSVC || BOOST_MSVC < 1900))
+    (defined(BOOST_MSVC) && (1600 <= BOOST_MSVC && BOOST_MSVC < 1900))
 #   define BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std
 {


### PR DESCRIPTION
As mentioned by @MarcelRaad within https://github.com/boostorg/fusion/commit/01a2d6557ea65fb4c5ec6f3e50d3340c1c13629d#commitcomment-10697799.

It will be applied for develop branch only since it is not a showstopper for 1.58.0.