### PR TITLE
Remove BOOST_CONSTEXPR on BOOST_FUSION_DEFINE_STRUCT 

### DIFF
--- a/include/boost/fusion/adapted/struct/detail/define_struct.hpp
+++ b/include/boost/fusion/adapted/struct/detail/define_struct.hpp
@@ -69,7 +69,7 @@
     ATTRIBUTES_SEQ, ATTRIBUTE_TUPEL_SIZE)                                       \
                                                                                 \
     template<typename Seq>                                                      \
-    BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED                              \
+    BOOST_FUSION_GPU_ENABLED                                                    \
     self_type&                                                                  \
     operator=(Seq const& seq)                                                   \
     {                                                                           \
@@ -128,7 +128,7 @@
         ATTRIBUTE_TUPEL_SIZE,                                                   \
         ATTRIBUTES_SEQ)                                                         \
                                                                                 \
-    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                    \
+    BOOST_FUSION_GPU_ENABLED                                                    \
     NAME()                                                                      \
       : BOOST_PP_SEQ_FOR_EACH_I_R(                                              \
             1,                                                                  \
@@ -137,7 +137,7 @@
             ATTRIBUTES_SEQ)                                                     \
     {}                                                                          \
                                                                                 \
-    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                    \
+    BOOST_FUSION_GPU_ENABLED                                                    \
     NAME(self_type const& other_self)                                           \
       : BOOST_PP_SEQ_FOR_EACH_I_R(                                              \
             1,                                                                  \
@@ -147,7 +147,7 @@
     {}                                                                          \
                                                                                 \
     template<typename Seq>                                                      \
-    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                    \
+    BOOST_FUSION_GPU_ENABLED                                                    \
     NAME(Seq const& seq                                                         \
         BOOST_PP_IF(                                                            \
             BOOST_PP_DEC(BOOST_PP_SEQ_SIZE(ATTRIBUTES_SEQ)),                    \
@@ -167,7 +167,7 @@
 #define BOOST_FUSION_DEFINE_STRUCT_CTOR_1(                                      \
         NAME, ATTRIBUTES_SEQ, ATTRIBUTE_TUPEL_SIZE)                             \
                                                                                 \
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                \
+        BOOST_FUSION_GPU_ENABLED                                                \
         explicit                                                                \
         NAME(boost::call_traits<                                                \
                 BOOST_PP_TUPLE_ELEM(                                            \
@@ -180,7 +180,7 @@
 #define BOOST_FUSION_DEFINE_TPL_STRUCT_CTOR_1(                                  \
         TEMPLATE_PARAMS_SEQ, NAME, ATTRIBUTES_SEQ, ATTRIBUTE_TUPEL_SIZE)        \
                                                                                 \
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                \
+        BOOST_FUSION_GPU_ENABLED                                                \
         explicit                                                                \
         NAME(typename boost::call_traits<                                       \
                 typename boost::fusion::detail::get_first_arg<                  \
@@ -217,7 +217,7 @@
 #define BOOST_FUSION_DEFINE_TPL_STRUCT_CTOR_N(                                  \
     TEMPLATE_PARAMS_SEQ, NAME, ATTRIBUTES_SEQ, ATTRIBUTE_TUPEL_SIZE)            \
                                                                                 \
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                \
+        BOOST_FUSION_GPU_ENABLED                                                \
         NAME(BOOST_PP_SEQ_FOR_EACH_I_R(                                         \
                 1,                                                              \
                 BOOST_FUSION_DEFINE_TPL_STRUCT_CTOR_ARG_I,                      \
@@ -245,7 +245,7 @@
 #define BOOST_FUSION_DEFINE_STRUCT_CTOR_N(                                      \
     NAME, ATTRIBUTES_SEQ, ATTRIBUTE_TUPEL_SIZE)                                 \
                                                                                 \
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                \
+        BOOST_FUSION_GPU_ENABLED                                \
         NAME(BOOST_PP_SEQ_FOR_EACH_I_R(                                         \
                 1,                                                              \
                 BOOST_FUSION_DEFINE_STRUCT_CTOR_ARG_I,                          \


### PR DESCRIPTION
Remove BOOST_CONSTEXPR on BOOST_FUSION_DEFINE_STRUCT constructors as it however adds the requirement that the user provided types are constant enabled.

Relates to https://svn.boost.org/trac/boost/ticket/11211
