### PR TITLE
Further test cases and fixes for #11211

### DIFF
--- a/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
+++ b/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
@@ -66,7 +66,7 @@
 #define BOOST_FUSION_IGNORE_2(ARG1, ARG2)
 
 #define BOOST_FUSION_MAKE_COPY_CONSTRUCTOR(NAME, ATTRIBUTES_SEQ)                \
-    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                    \
+    BOOST_FUSION_GPU_ENABLED                                                    \
     NAME(BOOST_PP_SEQ_FOR_EACH_I(                                               \
             BOOST_FUSION_MAKE_CONST_REF_PARAM,                                  \
             ~,                                                                  \
@@ -337,7 +337,7 @@
         typedef boost::mpl::int_<N> index;                                      \
         typedef boost_fusion_detail_Seq sequence_type;                          \
                                                                                 \
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                \
+        BOOST_FUSION_GPU_ENABLED                                                \
         BOOST_FUSION_ITERATOR_NAME(NAME)(boost_fusion_detail_Seq& seq)          \
             : seq_(seq)                                                         \
               BOOST_FUSION_DEFINE_ITERATOR_WKND_INIT_LIST_ENTRIES(              \

--- a/test/sequence/adapt_struct.cpp
+++ b/test/sequence/adapt_struct.cpp
@@ -67,6 +67,17 @@ namespace ns
         foo foo_;
         int y;
     };
+
+
+    // Testing non-constexpr compatible types
+    struct employee {
+      std::string name;
+      std::string nickname;
+
+      employee(std::string name, std::string nickname)
+        : name(name), nickname(nickname) 
+      {}
+    };
 }
 
 #if BOOST_PP_VARIADICS
@@ -96,6 +107,13 @@ namespace ns
         y
     )
 
+    BOOST_FUSION_ADAPT_STRUCT(
+        ns::employee,
+        name,
+        nickname
+    )
+        
+
 #else // BOOST_PP_VARIADICS
 
     BOOST_FUSION_ADAPT_STRUCT(
@@ -121,6 +139,12 @@ namespace ns
         ns::bar,
         (BOOST_FUSION_ADAPT_AUTO, foo_.x) // test that adapted members can actually be expressions
         (BOOST_FUSION_ADAPT_AUTO, y)
+    )
+
+    BOOST_FUSION_ADAPT_STRUCT(
+        ns::employee,
+        (std::string, name),
+        (BOOST_FUSION_ADAPT_AUTO, nickname)
     )
 
 #endif
@@ -223,6 +247,15 @@ main()
         BOOST_TEST(v2 > v1);
         BOOST_TEST(v2 >= v1);
     }
+
+    {
+        ns::employee emp("John Doe", "jdoe"); 
+        std::cout << at_c<0>(emp) << std::endl;
+        std::cout << at_c<1>(emp) << std::endl;
+
+        fusion::vector<std::string, std::string> v1("John Doe", "jdoe");
+        BOOST_TEST(emp == v1);
+    } 
 
     return boost::report_errors();
 }

--- a/test/sequence/define_struct.cpp
+++ b/test/sequence/define_struct.cpp
@@ -26,6 +26,14 @@ BOOST_FUSION_DEFINE_STRUCT(
 
 BOOST_FUSION_DEFINE_STRUCT(BOOST_PP_EMPTY(), s, (int, m))
 
+// Testing non-constexpr compatible types
+BOOST_FUSION_DEFINE_STRUCT(
+    (ns),
+    employee, 
+    (std::string, name)
+    (std::string, nickname)
+)
+
 int
 main()
 {
@@ -98,6 +106,14 @@ main()
 
         p = make_list(3,5);
         BOOST_TEST(p == make_vector(3,5));
+    }
+
+    {
+        ns::employee emp = make_list("John Doe", "jdoe"); 
+        std::cout << at_c<0>(emp) << std::endl;
+        std::cout << at_c<1>(emp) << std::endl;
+
+        BOOST_TEST(emp == make_vector("John Doe", "jdoe"));
     }
 
     return boost::report_errors();

--- a/test/sequence/define_struct_inline.cpp
+++ b/test/sequence/define_struct_inline.cpp
@@ -41,6 +41,13 @@ namespace ns
     BOOST_FUSION_DEFINE_STRUCT_INLINE(s, (int, m))
             
     BOOST_FUSION_DEFINE_STRUCT_INLINE(empty_struct, )
+
+    // Testing non-constexpr compatible types
+    BOOST_FUSION_DEFINE_STRUCT_INLINE(
+        employee, 
+        (std::string, name)
+        (std::string, nickname)
+    )
 }
 
 template <typename Point>
@@ -128,6 +135,17 @@ main()
 {
     run_test<cls::point>();        // test with non-template enclosing class
     run_test<tpl_cls<>::point>();  // test with template enclosing class
+
+    {
+        using namespace boost::fusion;
+
+        ns::employee emp = make_list("John Doe", "jdoe"); 
+        std::cout << at_c<0>(emp) << std::endl;
+        std::cout << at_c<1>(emp) << std::endl;
+
+        BOOST_TEST(emp == make_vector("John Doe", "jdoe"));
+    }
+
     return boost::report_errors();
 
 }


### PR DESCRIPTION
Relates to : https://svn.boost.org/trac/boost/ticket/11211

This removes the BOOST_CONSTEXPR macro from constructors generated by DEFINE_STRUCT_INLINE as they were generating the same error.

I also added some test cases for this. It runs under 
- clang v3.5.1 with std=c++11 & std=c++14
- g++ v4.9.2 with std=c++11 & std=c++14 

While I was doing the changes, I noticed that we may get more errors with BOOST_CONSTEXPR, as this was added in alot of place, and I'm not sure if we won't get more surprises as those in #11211.

@Flast did you make an auto-replace where BOOST_FUSION_GPU_ENABLED appeared or did you put them individually ? If it was made with auto-replace I think we have to take a tour on each place where it appears and determine if it makes sense, as GPU_ENABLED is not the same use case I think. 