### PR TITLE
Fix testcase when BOOST_PP_VARIADICS is disabled

### DIFF
--- a/test/sequence/adapt_struct.cpp
+++ b/test/sequence/adapt_struct.cpp
@@ -143,7 +143,7 @@ namespace ns
 
     BOOST_FUSION_ADAPT_STRUCT(
         ns::employee,
-        (std::string, name),
+        (std::string, name)
         (BOOST_FUSION_ADAPT_AUTO, nickname)
     )
 


### PR DESCRIPTION
As discovered by @Flast one testcase had a comma too much when BOOST_PP_VARIADICS is disabled. This commit just remove this comma.

Tested with gcc-4.9.2 : 

- bjam -j8 -a cxxflags="--std=c++98 -DBOOST_PP_VARIADICS=0"
- bjam -j8 -a cxxflags="--std=c++98 -DBOOST_PP_VARIADICS=1"
- bjam -j8 -a cxxflags="--std=c++11 -DBOOST_PP_VARIADICS=0"
- bjam -j8 -a cxxflags="--std=c++11 -DBOOST_PP_VARIADICS=1"
- bjam -j8 -a cxxflags="--std=c++14 -DBOOST_PP_VARIADICS=0"
- bjam -j8 -a cxxflags="--std=c++14 -DBOOST_PP_VARIADICS=1"

So this time should be ok. :smile: 