### PR TITLE
Fix ticket #11269 to adapt an empty struct

### DIFF
--- a/include/boost/fusion/adapted/struct/adapt_struct.hpp
+++ b/include/boost/fusion/adapted/struct/adapt_struct.hpp
@@ -17,6 +17,8 @@
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/comparison/less.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
+#include <boost/preprocessor/seq/seq.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/add_const.hpp>
@@ -61,25 +63,28 @@
             (1)NAME_SEQ,                                                        \
             struct_tag,                                                         \
             0,                                                                  \
-            BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(__VA_ARGS__),           \
+            BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(                        \
+                BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)),                         \
             BOOST_FUSION_ADAPT_STRUCT_C)
 
-#   define BOOST_FUSION_ADAPT_STRUCT(NAME, ...)                                 \
+#   define BOOST_FUSION_ADAPT_STRUCT(...)                                       \
         BOOST_FUSION_ADAPT_STRUCT_BASE(                                         \
             (0),                                                                \
-            (0)(NAME),                                                          \
+            (0)(BOOST_PP_SEQ_HEAD(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))),      \
             struct_tag,                                                         \
             0,                                                                  \
-            BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(__VA_ARGS__),           \
+            BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(                        \
+              BOOST_PP_SEQ_TAIL(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))),        \
             BOOST_FUSION_ADAPT_STRUCT_C)
 
-#   define BOOST_FUSION_ADAPT_STRUCT_AS_VIEW(NAME, ...)                         \
+#   define BOOST_FUSION_ADAPT_STRUCT_AS_VIEW(...)                               \
         BOOST_FUSION_ADAPT_STRUCT_BASE(                                         \
             (0),                                                                \
-            (0)(NAME),                                                          \
+            (0)(BOOST_PP_SEQ_HEAD(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))),      \
             struct_tag,                                                         \
             1,                                                                  \
-            BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(__VA_ARGS__),           \
+            BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(                        \
+              BOOST_PP_SEQ_TAIL(BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))),        \
             BOOST_FUSION_ADAPT_STRUCT_C)
         
 #else // BOOST_PP_VARIADICS

--- a/include/boost/fusion/adapted/struct/detail/adapt_base_attr_filler.hpp
+++ b/include/boost/fusion/adapted/struct/detail/adapt_base_attr_filler.hpp
@@ -49,14 +49,16 @@
 #   define BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER_OP(r, unused, elem)      \
         BOOST_PP_IF(BOOST_FUSION_PP_IS_SEQ(elem),                               \
             BOOST_PP_CAT( BOOST_FUSION_ADAPT_STRUCT_FILLER_0 elem ,_END),       \
-            BOOST_FUSION_ADAPT_STRUCT_WRAP_ATTR(BOOST_FUSION_ADAPT_AUTO,        \
-                elem))
+            BOOST_PP_IF(BOOST_PP_IS_EMPTY(elem),                                \
+              BOOST_PP_EMPTY(),                                                 \
+              BOOST_FUSION_ADAPT_STRUCT_WRAP_ATTR(BOOST_FUSION_ADAPT_AUTO,elem))\
+            )
 
-#   define BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(...)                     \
+#   define BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER(VA_ARGS_SEQ)             \
         BOOST_PP_SEQ_PUSH_FRONT(                                                \
             BOOST_PP_SEQ_FOR_EACH(                                              \
                 BOOST_FUSION_ADAPT_STRUCT_ATTRIBUTES_FILLER_OP,                 \
-                unused, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)),                 \
+                unused, VA_ARGS_SEQ),                                           \
             (0,0))
 
 #endif // BOOST_PP_VARIADICS

--- a/test/sequence/adapt_struct.cpp
+++ b/test/sequence/adapt_struct.cpp
@@ -149,6 +149,9 @@ namespace ns
 
 #endif
 
+struct empty_struct {};
+BOOST_FUSION_ADAPT_STRUCT(empty_struct,); 
+
 int
 main()
 {


### PR DESCRIPTION
https://svn.boost.org/trac/boost/ticket/11269

This fixes adapting empty structs with BOOST_FUSION_ADAPT_STRUCT as requested in 11269. 

Tested on gcc 4.9.2 : 
- `../../../b2 cxxflags="-DBOOST_PP_VARIADICS=0" -a -j8`
- `../../../b2 cxxflags="-DBOOST_PP_VARIADICS=1" -a -j8`

I'm not sure it's enough as I told on the trac ticket. Do you think there are more use cases adapting empty structs or classes ?

Because this fixes only the specific BOOST_FUSION_ADAPT_STRUCT.