### PR TITLE
Adds test case for each adapter macros we support to adapt an empty type

### DIFF
--- a/test/sequence/adapt_adt.cpp
+++ b/test/sequence/adapt_adt.cpp
@@ -149,6 +149,9 @@ namespace ns
 
 #endif
 
+class empty_adt{};
+BOOST_FUSION_ADAPT_ADT(empty_adt,)
+
 int
 main()
 {

--- a/test/sequence/adapt_adt_named.cpp
+++ b/test/sequence/adapt_adt_named.cpp
@@ -77,6 +77,10 @@ BOOST_FUSION_ADAPT_ADT_NAMED(
 
 #endif // BOOST_PP_VARIADICS
 
+
+class empty_adt{};
+BOOST_FUSION_ADAPT_ADT_NAMED(empty_adt,renamed_empty_adt,)
+
 int
 main()
 {

--- a/test/sequence/adapt_assoc_adt.cpp
+++ b/test/sequence/adapt_assoc_adt.cpp
@@ -70,6 +70,9 @@ BOOST_FUSION_ADAPT_ASSOC_ADT(
 
 #endif
 
+class empty_adt{};
+BOOST_FUSION_ADAPT_ASSOC_ADT(empty_adt,)
+
 int
 main()
 {

--- a/test/sequence/adapt_assoc_adt_named.cpp
+++ b/test/sequence/adapt_assoc_adt_named.cpp
@@ -52,6 +52,9 @@ BOOST_FUSION_ADAPT_ASSOC_ADT_NAMED(
     (int, int, obj.get_y(), obj.set_y(val), ns::y_member)
 )
 
+class empty_adt{};
+BOOST_FUSION_ADAPT_ASSOC_ADT_NAMED(empty_adt, renamed_empty_adt,)
+
 int
 main()
 {

--- a/test/sequence/adapt_assoc_struct.cpp
+++ b/test/sequence/adapt_assoc_struct.cpp
@@ -71,6 +71,9 @@ namespace ns
 
 #endif
 
+struct empty_struct {};
+BOOST_FUSION_ADAPT_ASSOC_STRUCT(empty_struct,); 
+
 int
 main()
 {

--- a/test/sequence/adapt_assoc_struct_named.cpp
+++ b/test/sequence/adapt_assoc_struct_named.cpp
@@ -38,6 +38,9 @@ BOOST_FUSION_ADAPT_ASSOC_STRUCT_NAMED(
     (int, y, ns::y_member)
 )
 
+struct empty_struct {};
+BOOST_FUSION_ADAPT_ASSOC_STRUCT_NAMED(empty_struct, renamed_empty_struct,); 
+
 int
 main()
 {

--- a/test/sequence/adapt_assoc_tpl_adt.cpp
+++ b/test/sequence/adapt_assoc_tpl_adt.cpp
@@ -71,6 +71,20 @@ BOOST_FUSION_ADAPT_ASSOC_TPL_ADT(
 
 #endif
 
+template <typename TypeToConstruct>
+class empty_adt_templated_factory {
+
+  TypeToConstruct operator()() {
+    return TypeToConstruct();
+  }
+
+};
+
+BOOST_FUSION_ADAPT_ASSOC_TPL_ADT(
+    (TypeToConstruct),
+    (empty_adt_templated_factory)(TypeToConstruct),
+) 
+
 int
 main()
 {

--- a/test/sequence/adapt_assoc_tpl_struct.cpp
+++ b/test/sequence/adapt_assoc_tpl_struct.cpp
@@ -69,6 +69,20 @@ namespace ns
   )
 #endif
 
+template <typename TypeToConstruct>
+struct empty_struct_templated_factory {
+
+  TypeToConstruct operator()() {
+    return TypeToConstruct();
+  }
+
+};
+
+BOOST_FUSION_ADAPT_ASSOC_TPL_STRUCT(
+    (TypeToConstruct),
+    (empty_struct_templated_factory)(TypeToConstruct),
+) 
+
 int
 main()
 {

--- a/test/sequence/adapt_struct.cpp
+++ b/test/sequence/adapt_struct.cpp
@@ -150,7 +150,7 @@ namespace ns
 #endif
 
 struct empty_struct {};
-BOOST_FUSION_ADAPT_STRUCT(empty_struct,); 
+BOOST_FUSION_ADAPT_STRUCT(empty_struct,)
 
 int
 main()

--- a/test/sequence/adapt_struct_named.cpp
+++ b/test/sequence/adapt_struct_named.cpp
@@ -71,6 +71,10 @@ namespace ns
 
 #endif 
 
+struct empty_struct {};
+BOOST_FUSION_ADAPT_STRUCT_NAMED(empty_struct, renamed_empty_struct, )
+BOOST_FUSION_ADAPT_STRUCT_NAMED_NS(empty_struct, (ns1), renamed_empty_struct1, ) 
+
 int
 main()
 {

--- a/test/sequence/adapt_tpl_adt.cpp
+++ b/test/sequence/adapt_tpl_adt.cpp
@@ -79,6 +79,20 @@ namespace ns
   )
 #endif
 
+template <typename TypeToConstruct>
+class empty_adt_templated_factory {
+
+  TypeToConstruct operator()() {
+    return TypeToConstruct();
+  }
+
+};
+
+BOOST_FUSION_ADAPT_TPL_ADT(
+    (TypeToConstruct),
+    (empty_adt_templated_factory)(TypeToConstruct),
+) 
+
 int
 main()
 {

--- a/test/sequence/adapt_tpl_struct.cpp
+++ b/test/sequence/adapt_tpl_struct.cpp
@@ -69,6 +69,19 @@ namespace ns
 
 #endif
 
+template <typename TypeToConstruct>
+struct empty_struct_templated_factory {
+
+  TypeToConstruct operator()() {
+    return TypeToConstruct();
+  }
+
+};
+
+BOOST_FUSION_ADAPT_TPL_STRUCT(
+    (TypeToConstruct),
+    (empty_struct_templated_factory)(TypeToConstruct),
+) 
 
 int
 main()


### PR DESCRIPTION
Hi @djowel,

As #75 already fixed the problem of adapting an empty struct, this PR provides testcases for ADAPT_ADT* and ADAPT_STRUCT* macros to ensure we can use any of them with empty types.

This closes IMHO the bug entry https://svn.boost.org/trac/boost/ticket/11269.

I have all tests passing under GCC 4.9.2 & Clang (3.5.1) in the following combinations : 

- bjam cxxflags=" -DBOOST_PP_VARIADICS=0 " 
- bjam cxxflags=" -DBOOST_PP_VARIADICS=1 "
- bjam cxxflags=" -DBOOST_PP_VARIADICS=0 --std=c++11 "
- bjam cxxflags=" -DBOOST_PP_VARIADICS=1 --std=c++11 "

Cheers & Enjoy cppnow :smile: Would have loved to be at the x3 presentation.