### PR TITLE
Stop Using type_traits details.

### DIFF
--- a/include/boost/fusion/functional/invocation/detail/that_ptr.hpp
+++ b/include/boost/fusion/functional/invocation/detail/that_ptr.hpp
@@ -12,7 +12,6 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/get_pointer.hpp>
 #include <boost/utility/addressof.hpp>
-#include <boost/type_traits/config.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
 namespace boost { namespace fusion { namespace detail
@@ -61,10 +60,16 @@ namespace boost { namespace fusion { namespace detail
 
     template <typename PtrOrSmartPtr> struct non_const_pointee;
 
-    namespace adl_barrier
+#if defined(BOOST_MSVC) || (defined(__BORLANDC__) && !defined(BOOST_DISABLE_WIN32))
+#   define BOOST_FUSION_TRAIT_DECL __cdecl
+#else
+#   define BOOST_FUSION_TRAIT_DECL /**/
+#endif
+
+namespace adl_barrier
     {
         using boost::get_pointer;
-        void const * BOOST_TT_DECL get_pointer(...); // fallback
+        void const * BOOST_FUSION_TRAIT_DECL get_pointer(...); // fallback
   
         template< typename T> char const_tester(T *);
         template< typename T> long const_tester(T const *);


### PR DESCRIPTION
Best not to use type_traits undocumented details, these will be moving soon, and use of this header will warn loud and clear if you continue to use it.