### PR TITLE
Remove obsolete workaround.

### DIFF
--- a/include/boost/fusion/sequence/comparison/less_equal.hpp
+++ b/include/boost/fusion/sequence/comparison/less_equal.hpp
@@ -13,7 +13,6 @@
 #include <boost/fusion/sequence/intrinsic/end.hpp>
 #include <boost/fusion/sequence/intrinsic/size.hpp>
 #include <boost/fusion/sequence/comparison/enable_comparison.hpp>
-#include <boost/fusion/support/is_sequence.hpp>
 
 #if defined(FUSION_DIRECT_OPERATOR_USAGE)
 #include <boost/fusion/sequence/comparison/detail/less_equal.hpp>
@@ -38,36 +37,6 @@ namespace boost { namespace fusion
 
     namespace operators
     {
-#if defined(BOOST_MSVC) && (BOOST_MSVC <= 1400)
-// Workaround for  VC8.0 and VC7.1
-        template <typename Seq1, typename Seq2>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        inline bool
-        operator<=(sequence_base<Seq1> const& a, sequence_base<Seq2> const& b)
-        {
-            return less_equal(a.derived(), b.derived());
-        }
-
-        template <typename Seq1, typename Seq2>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        inline typename disable_if<traits::is_native_fusion_sequence<Seq2>, bool>::type
-        operator<=(sequence_base<Seq1> const& a, Seq2 const& b)
-        {
-            return less_equal(a.derived(), b);
-        }
-
-        template <typename Seq1, typename Seq2>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        inline typename disable_if<traits::is_native_fusion_sequence<Seq1>, bool>::type
-        operator<=(Seq1 const& a, sequence_base<Seq2> const& b)
-        {
-            return less_equal(a, b.derived());
-        }
-
-#else
-// Somehow VC8.0 and VC7.1 does not like this code
-// but barfs somewhere else.
-
         template <typename Seq1, typename Seq2>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         inline typename
@@ -79,7 +48,6 @@ namespace boost { namespace fusion
         {
             return fusion::less_equal(a, b);
         }
-#endif
     }
     using operators::operator<=;
 }}


### PR DESCRIPTION
It will fix two failure: [fusion - adapt_adt / msvc-8.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08a-win2012R2-64on64-boost-bin-v2-libs-fusion-test-adapt_adt-test-msvc-8-0-dbg-adrs-mdl-64-thrd-mlt.html) and [fusion - adapt_tpl_adt / msvc-8.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08a-win2012R2-64on64-boost-bin-v2-libs-fusion-test-adapt_tpl_adt-test-msvc-8-0-dbg-adrs-mdl-64-thrd-mlt.html)