### PR TITLE
Fix issue 11267

### DIFF
--- a/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
@@ -94,13 +94,13 @@ namespace boost { namespace fusion {
             {}
 
         template<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, typename U)>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         deque(deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)> const& seq)
             : base(seq)
             {}
 
         template<typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq, typename disable_if<is_convertible<Sequence, T0> >::type* /*dummy*/ = 0)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
@@ -129,7 +129,7 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || \
     (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
         template <typename T0_>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
           , typename enable_if<is_convertible<T0_, T0> >::type* /*dummy*/ = 0
          )
@@ -140,7 +140,7 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
             : base(std::forward<deque>(rhs))
             {}
         template<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, typename U)>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         deque(deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>&& seq
             , typename disable_if<
                   is_convertible<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>, T0>

--- a/include/boost/fusion/container/deque/detail/cpp03/deque_keyed_values.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/deque_keyed_values.hpp
@@ -24,7 +24,6 @@
 
 #include <boost/mpl/plus.hpp>
 #include <boost/mpl/int.hpp>
-#include <boost/mpl/print.hpp>
 
 #define FUSION_VOID(z, n, _) void_
 

--- a/include/boost/fusion/container/list/cons.hpp
+++ b/include/boost/fusion/container/list/cons.hpp
@@ -73,7 +73,7 @@ namespace boost { namespace fusion
             : car(rhs.car), cdr(rhs.cdr) {}
 
         template <typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         cons(
             Sequence const& seq
           , typename boost::enable_if<

--- a/include/boost/fusion/container/list/list.hpp
+++ b/include/boost/fusion/container/list/list.hpp
@@ -60,7 +60,7 @@ namespace boost { namespace fusion
             : inherited_type(rhs) {}
 
         template <typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
             , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
             : inherited_type(rhs) {}

--- a/include/boost/fusion/container/map/detail/cpp03/map.hpp
+++ b/include/boost/fusion/container/map/detail/cpp03/map.hpp
@@ -85,7 +85,7 @@ namespace boost { namespace fusion
             : data(rhs.data) {}
 
         template <typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         map(Sequence const& rhs)
             : data(rhs) {}
 

--- a/include/boost/fusion/container/map/map.hpp
+++ b/include/boost/fusion/container/map/map.hpp
@@ -66,21 +66,21 @@ namespace boost { namespace fusion
         {}
 
         template <typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         map(Sequence const& seq
           , typename enable_if<traits::is_sequence<Sequence>>::type* /*dummy*/ = 0)
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 
         template <typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         map(Sequence& seq
           , typename enable_if<traits::is_sequence<Sequence>>::type* /*dummy*/ = 0)
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 
         template <typename Sequence>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         map(Sequence&& seq
           , typename enable_if<traits::is_sequence<Sequence>>::type* /*dummy*/ = 0)
           : base_type(begin(seq), detail::map_impl_from_iterator())
@@ -93,7 +93,7 @@ namespace boost { namespace fusion
         {}
 
         template <typename First, typename ...T_>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         map(First&& first, T_&&... rest)
           : base_type(BOOST_FUSION_FWD_ELEM(First, first), BOOST_FUSION_FWD_ELEM(T_, rest)...)
         {}

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -116,16 +116,6 @@ namespace boost { namespace fusion
             : vec(rhs.vec) {}
 
         template <typename Sequence>
-        // XXX:
-#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
-FUSION_HASH if !defined(BOOST_CLANG)
-        BOOST_CONSTEXPR
-FUSION_HASH endif
-#else
-#if !defined(BOOST_CLANG)
-        BOOST_CONSTEXPR
-#endif
-#endif
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
             typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)

--- a/include/boost/fusion/support/pair.hpp
+++ b/include/boost/fusion/support/pair.hpp
@@ -49,7 +49,7 @@ namespace boost { namespace fusion
 
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename Second2>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_GPU_ENABLED
         pair(Second2&& val
           , typename boost::disable_if<is_lvalue_reference<Second2> >::type* /* dummy */ = 0
           , typename boost::enable_if<is_convertible<Second2, Second> >::type* /*dummy*/ = 0

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -78,6 +78,7 @@ project
     [ run sequence/list_make.cpp :  :  :  : ]
     [ run sequence/list_misc.cpp :  :  :  : ]
     [ run sequence/list_mutate.cpp :  :  :  : ]
+    [ run sequence/list_nest.cpp :  :  :  : ]
     [ run sequence/list_tie.cpp :  :  :  : ]
     [ run sequence/list_value_at.cpp :  :  :  : ]
     [ run sequence/deque_comparison.cpp :  :  :  : ]
@@ -89,6 +90,7 @@ project
     [ run sequence/deque_misc.cpp :  :  :  : ]
     [ run sequence/deque_move.cpp :  :  :  : ]
     [ run sequence/deque_mutate.cpp :  :  :  : ]
+    [ run sequence/deque_nest.cpp :  :  :  : ]
     [ run sequence/deque_tie.cpp :  :  :  : ]
     [ run sequence/deque_value_at.cpp :  :  :  : ]
     [ run sequence/front_extended_deque.cpp :  :  :  : ]
@@ -131,6 +133,7 @@ project
     [ run sequence/vector_move.cpp :  :  :  : ]
     [ run sequence/vector_mutate.cpp :  :  :  : ]
     [ run sequence/vector_n.cpp :  :  :  : ]
+    [ run sequence/vector_nest.cpp :  :  :  : ]
     [ run sequence/vector_hash.cpp :  :  :  : ]
     [ run sequence/vector_tie.cpp :  :  :  : ]
     [ run sequence/vector_value_at.cpp :  :  :  : ]
@@ -184,6 +187,7 @@ project
     [ compile support/pair_map.cpp : : : : ]
     [ compile support/pair_set.cpp : : : : ]
     [ compile support/pair_vector.cpp : : : : ]
+    [ compile support/pair_nest.cpp : : : : ]
 
 #   [ compile-fail xxx.cpp :  :  :  :  ]
 

--- a/test/algorithm/pop_back.cpp
+++ b/test/algorithm/pop_back.cpp
@@ -65,8 +65,8 @@ main()
         std::cout << pop_back(sv) << std::endl;
 
         // Compile check only
-        begin(pop_back(sv)) == end(sv);
-        end(pop_back(sv)) == begin(sv);
+        (void)(begin(pop_back(sv)) == end(sv));
+        (void)(end(pop_back(sv)) == begin(sv));
     }
 
     // $$$ JDG: TODO add compile fail facility $$$

--- a/test/sequence/deque_nest.cpp
+++ b/test/sequence/deque_nest.cpp
@@ -1,0 +1,19 @@
+/*=============================================================================
+    Copyright (C) 2015 Kohei Takahshi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/container/deque/deque.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#define FUSION_SEQUENCE deque
+#include "nest.hpp"
+
+int
+main()
+{
+    test();
+    return boost::report_errors();
+}
+

--- a/test/sequence/iterator.hpp
+++ b/test/sequence/iterator.hpp
@@ -164,9 +164,11 @@ void test()
 
         BOOST_STATIC_ASSERT((is_same<boost::fusion::result_of::deref<i0>::type, int&>::value));
         BOOST_STATIC_ASSERT((is_same<boost::fusion::result_of::deref<i1>::type, char&>::value));
+        BOOST_STATIC_ASSERT((is_same<boost::fusion::result_of::deref<i2>::type, char&>::value));
 
         BOOST_STATIC_ASSERT((is_same<boost::fusion::result_of::value_of<i0>::type, int>::value));
         BOOST_STATIC_ASSERT((is_same<boost::fusion::result_of::value_of<i1>::type, char&>::value));
+        BOOST_STATIC_ASSERT((is_same<boost::fusion::result_of::value_of<i2>::type, char&>::value));
     }
 
     { // Testing advance

--- a/test/sequence/list_nest.cpp
+++ b/test/sequence/list_nest.cpp
@@ -1,0 +1,19 @@
+/*=============================================================================
+    Copyright (C) 2015 Kohei Takahshi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/container/list/list.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#define FUSION_SEQUENCE list
+#include "nest.hpp"
+
+int
+main()
+{
+    test();
+    return boost::report_errors();
+}
+

--- a/test/sequence/map.cpp
+++ b/test/sequence/map.cpp
@@ -111,6 +111,7 @@ main()
         pair<int, char> a = at_c<0>(m); (void) a;
         pair<double, std::string> b = at_c<1>(m);
         pair<abstract, int> c = at_c<2>(m);
+        (void)c;
     }
 
     // iterators & random access interface.
@@ -154,6 +155,7 @@ main()
         // make sure that the correct constructor is called
         pair<int, copy_all> p1;
         pair<int, copy_all> p2 = p1;
+        (void)p2;
     }
     
     {

--- a/test/sequence/nest.hpp
+++ b/test/sequence/nest.hpp
@@ -1,0 +1,58 @@
+/*=============================================================================
+    Copyright (C) 2015 Kohei Takahshi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#include <utility>
+#include <boost/config.hpp>
+
+template <typename C>
+void test_copy()
+{
+    C src;
+    C dst = src;
+    (void)dst;
+}
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+template <typename C>
+void test_move()
+{
+    C src;
+    C dst = std::move(src);
+    (void)dst;
+}
+#endif
+
+template <typename C>
+void test_all()
+{
+    test_copy<C>();
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    test_move<C>();
+#endif
+}
+
+void
+test()
+{
+    using namespace boost::fusion;
+
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<> > >();
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<>, int> >();
+    test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<> > >();
+    test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<>, float> >();
+
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<int> > >();
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<int>, int> >();
+    test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<int> > >();
+    test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<int>, float> >();
+
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<int, float> > >();
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<int, float>, int> >();
+    test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<int, float> > >();
+    test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<int, float>, float> >();
+}
+

--- a/test/sequence/vector_nest.cpp
+++ b/test/sequence/vector_nest.cpp
@@ -1,0 +1,19 @@
+/*=============================================================================
+    Copyright (C) 2015 Kohei Takahshi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/container/vector/vector.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#define FUSION_SEQUENCE vector
+#include "nest.hpp"
+
+int
+main()
+{
+    test();
+    return boost::report_errors();
+}
+

--- a/test/support/pair_nest.cpp
+++ b/test/support/pair_nest.cpp
@@ -1,0 +1,24 @@
+/*=============================================================================
+    Copyright (c) 2015 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/core/ignore_unused.hpp>
+#include <boost/fusion/support/pair.hpp>
+
+using namespace boost::fusion;
+
+template <typename C>
+void copy()
+{
+    pair<int, C> src;
+    pair<int, C> dest = src;
+    boost::ignore_unused(dest);
+}
+
+int main()
+{
+    copy<pair<void, float> >();
+}
+


### PR DESCRIPTION
This PR will fix [#11267](https://svn.boost.org/trac/boost/ticket/11267).
It is one of regressions in 1.58.0 release: constexpr support.

> Compiler yields compile error within a function witch used in unevaluate
context of constexpr function because of CWG 1581 [2].
> 
1. https://llvm.org/bugs/show_bug.cgi?id=23135
2. http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1581

Note: Regenerating preprocessed files is required.