### PR TITLE
Variadic fusion::list.

### DIFF
--- a/include/boost/fusion/container/generation/detail/pp_list_tie.hpp
+++ b/include/boost/fusion/container/generation/detail/pp_list_tie.hpp
@@ -53,7 +53,7 @@ namespace boost { namespace fusion
 // $$$ shouldn't we remove_reference first to allow references? $$$
 #define BOOST_FUSION_REF(z, n, data) BOOST_PP_CAT(T, n)&
 
-#define BOOST_PP_FILENAME_1 <boost/fusion/container/generation/detail/list_tie.hpp>
+#define BOOST_PP_FILENAME_1 <boost/fusion/container/generation/detail/pp_list_tie.hpp>
 #define BOOST_PP_ITERATION_LIMITS (1, FUSION_MAX_LIST_SIZE)
 #include BOOST_PP_ITERATE()
 

--- a/include/boost/fusion/container/generation/list_tie.hpp
+++ b/include/boost/fusion/container/generation/list_tie.hpp
@@ -10,7 +10,35 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/container/list/list.hpp>
 
+#if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
 # include <boost/fusion/container/generation/detail/pp_list_tie.hpp>
+#else
+
+///////////////////////////////////////////////////////////////////////////////
+// C++11 variadic interface
+///////////////////////////////////////////////////////////////////////////////
+
+namespace boost { namespace fusion
+{
+    namespace result_of
+    {
+        template <typename ...T>
+        struct list_tie
+        {
+            typedef list<T&...> type;
+        };
+    }
+
+    template <typename ...T>
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+    inline list<T&...>
+    list_tie(T&... arg)
+    {
+        return list<T&...>(arg...);
+    }
+}}
+
+#endif
 
 #endif
 

--- a/include/boost/fusion/container/generation/make_list.hpp
+++ b/include/boost/fusion/container/generation/make_list.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace fusion
     }
 
     template <typename ...T>
-    BOOST_FUSION_GPU_ENABLED
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline list<typename detail::as_fusion_element<T>::type...>
     make_list(T const&... arg)
     {

--- a/include/boost/fusion/container/generation/make_list.hpp
+++ b/include/boost/fusion/container/generation/make_list.hpp
@@ -27,16 +27,16 @@ namespace boost { namespace fusion
         template <typename ...T>
         struct make_list
         {
-            typedef list<T...> type;
+            typedef list<typename detail::as_fusion_element<T>::type...> type;
         };
     }
 
     template <typename ...T>
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-    inline list<typename detail::as_fusion_element<T>::type...>
+    inline typename result_of::make_list<T...>::type
     make_list(T const&... arg)
     {
-        return list<typename detail::as_fusion_element<T>::type...>(arg...);
+        return typename result_of::make_list<T...>::type(arg...);
     }
  }}
 

--- a/include/boost/fusion/container/generation/make_list.hpp
+++ b/include/boost/fusion/container/generation/make_list.hpp
@@ -10,7 +10,37 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/container/list/list.hpp>
 
+#if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
 # include <boost/fusion/container/generation/detail/pp_make_list.hpp>
+#else
 
+///////////////////////////////////////////////////////////////////////////////
+// C++11 variadic interface
+///////////////////////////////////////////////////////////////////////////////
+
+#include <boost/fusion/support/detail/as_fusion_element.hpp>
+
+namespace boost { namespace fusion
+{
+    namespace result_of
+    {
+        template <typename ...T>
+        struct make_list
+        {
+            typedef list<T...> type;
+        };
+    }
+
+    template <typename ...T>
+    BOOST_FUSION_GPU_ENABLED
+    inline list<typename detail::as_fusion_element<T>::type...>
+    make_list(T const&... arg)
+    {
+        return list<typename detail::as_fusion_element<T>::type...>(arg...);
+    }
+ }}
+
+
+#endif
 #endif
 

--- a/include/boost/fusion/container/list/detail/cpp03/list.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/list.hpp
@@ -46,10 +46,9 @@ namespace boost { namespace fusion
         typedef
             detail::list_to_cons<BOOST_PP_ENUM_PARAMS(FUSION_MAX_LIST_SIZE, T)>
         list_to_cons;
-
-    public:
         typedef typename list_to_cons::type inherited_type;
 
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list10.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list10.hpp
@@ -18,8 +18,8 @@ namespace boost { namespace fusion
         typedef
             detail::list_to_cons<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9>
         list_to_cons;
-    public:
         typedef typename list_to_cons::type inherited_type;
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list20.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list20.hpp
@@ -18,8 +18,8 @@ namespace boost { namespace fusion
         typedef
             detail::list_to_cons<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19>
         list_to_cons;
-    public:
         typedef typename list_to_cons::type inherited_type;
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list30.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list30.hpp
@@ -18,8 +18,8 @@ namespace boost { namespace fusion
         typedef
             detail::list_to_cons<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19 , T20 , T21 , T22 , T23 , T24 , T25 , T26 , T27 , T28 , T29>
         list_to_cons;
-    public:
         typedef typename list_to_cons::type inherited_type;
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list40.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list40.hpp
@@ -18,8 +18,8 @@ namespace boost { namespace fusion
         typedef
             detail::list_to_cons<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19 , T20 , T21 , T22 , T23 , T24 , T25 , T26 , T27 , T28 , T29 , T30 , T31 , T32 , T33 , T34 , T35 , T36 , T37 , T38 , T39>
         list_to_cons;
-    public:
         typedef typename list_to_cons::type inherited_type;
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list50.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list50.hpp
@@ -18,8 +18,8 @@ namespace boost { namespace fusion
         typedef
             detail::list_to_cons<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19 , T20 , T21 , T22 , T23 , T24 , T25 , T26 , T27 , T28 , T29 , T30 , T31 , T32 , T33 , T34 , T35 , T36 , T37 , T38 , T39 , T40 , T41 , T42 , T43 , T44 , T45 , T46 , T47 , T48 , T49>
         list_to_cons;
-    public:
         typedef typename list_to_cons::type inherited_type;
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/detail/list_to_cons.hpp
+++ b/include/boost/fusion/container/list/detail/list_to_cons.hpp
@@ -1,5 +1,5 @@
 /*=============================================================================
-    Copyright (c) 2014 Kohei Takahashi
+    Copyright (c) 2014-2015 Kohei Takahashi
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,6 +7,7 @@
 #ifndef FUSION_LIST_MAIN_10262014_0447
 #define FUSION_LIST_MAIN_10262014_0447
 
+#include <boost/config.hpp>
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/container/list/list_fwd.hpp>
 
@@ -21,6 +22,7 @@
 // C++11 interface
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/container/list/cons.hpp>
+#include <boost/fusion/support/detail/access.hpp>
 
 namespace boost { namespace fusion { namespace detail
 {
@@ -31,23 +33,9 @@ namespace boost { namespace fusion { namespace detail
     struct list_to_cons<>
     {
         typedef nil_ type;
-    };
 
-    template <typename Head>
-    struct list_to_cons<Head>
-    {
-        typedef Head head_type;
-        typedef list_to_cons<> tail_list_to_cons;
-        typedef typename tail_list_to_cons::type tail_type;
-
-        typedef cons<head_type, tail_type> type;
-
-        BOOST_FUSION_GPU_ENABLED
-        static type
-        call(typename detail::call_param<Head>::type _h)
-        {
-            return type(_h);
-        }
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        static type call() { return type(); }
     };
 
     template <typename Head, typename ...Tail>
@@ -59,7 +47,7 @@ namespace boost { namespace fusion { namespace detail
 
         typedef cons<head_type, tail_type> type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         static type
         call(typename detail::call_param<Head>::type _h,
              typename detail::call_param<Tail>::type ..._t)

--- a/include/boost/fusion/container/list/detail/list_to_cons.hpp
+++ b/include/boost/fusion/container/list/detail/list_to_cons.hpp
@@ -13,6 +13,61 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Without variadics, we will use the PP version
 ///////////////////////////////////////////////////////////////////////////////
+#if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
 # include <boost/fusion/container/list/detail/cpp03/list_to_cons.hpp>
+#else
 
+///////////////////////////////////////////////////////////////////////////////
+// C++11 interface
+///////////////////////////////////////////////////////////////////////////////
+#include <boost/fusion/container/list/cons.hpp>
+
+namespace boost { namespace fusion { namespace detail
+{
+    template <typename ...T>
+    struct list_to_cons;
+
+    template <>
+    struct list_to_cons<>
+    {
+        typedef nil_ type;
+    };
+
+    template <typename Head>
+    struct list_to_cons<Head>
+    {
+        typedef Head head_type;
+        typedef list_to_cons<> tail_list_to_cons;
+        typedef typename tail_list_to_cons::type tail_type;
+
+        typedef cons<head_type, tail_type> type;
+
+        BOOST_FUSION_GPU_ENABLED
+        static type
+        call(typename detail::call_param<Head>::type _h)
+        {
+            return type(_h);
+        }
+    };
+
+    template <typename Head, typename ...Tail>
+    struct list_to_cons<Head, Tail...>
+    {
+        typedef Head head_type;
+        typedef list_to_cons<Tail...> tail_list_to_cons;
+        typedef typename tail_list_to_cons::type tail_type;
+
+        typedef cons<head_type, tail_type> type;
+
+        BOOST_FUSION_GPU_ENABLED
+        static type
+        call(typename detail::call_param<Head>::type _h,
+             typename detail::call_param<Tail>::type ..._t)
+        {
+            return type(_h, tail_list_to_cons::call(_t...));
+        }
+    };
+}}}
+
+#endif
 #endif

--- a/include/boost/fusion/container/list/list.hpp
+++ b/include/boost/fusion/container/list/list.hpp
@@ -20,12 +20,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 // C++11 interface
 ///////////////////////////////////////////////////////////////////////////////
+#include <utility>
 #include <boost/fusion/container/list/detail/list_to_cons.hpp>
 
 namespace boost { namespace fusion
 {
     struct nil_;
-    struct void_;
 
     template <>
     struct list<>
@@ -40,6 +40,7 @@ namespace boost { namespace fusion
         list()
             : inherited_type() {}
 
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs)
@@ -53,6 +54,21 @@ namespace boost { namespace fusion
             inherited_type::operator=(rhs);
             return *this;
         }
+#else
+        template <typename Sequence>
+        BOOST_FUSION_GPU_ENABLED
+        list(Sequence&& rhs)
+            : inherited_type(std::forward<Sequence>(rhs)) {}
+
+        template <typename Sequence>
+        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        list&
+        operator=(Sequence&& rhs)
+        {
+            inherited_type::operator=(std::forward<Sequence>(rhs));
+            return *this;
+        }
+#endif
     };
 
     template <typename ...T>
@@ -68,30 +84,24 @@ namespace boost { namespace fusion
         list()
             : inherited_type() {}
 
-        template <typename ...U>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        list(list<U...> const& rhs)
-            : inherited_type(rhs) {}
-
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs)
             : inherited_type(rhs) {}
+#else
+        template <typename Sequence>
+        BOOST_FUSION_GPU_ENABLED
+        list(Sequence&& rhs)
+            : inherited_type(std::forward<Sequence>(rhs)) {}
+#endif
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit
         list(typename detail::call_param<T>::type ...args)
             : inherited_type(list_to_cons::call(args...)) {}
 
-        template <typename ...U>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        list&
-        operator=(list<U...> const& rhs)
-        {
-            inherited_type::operator=(rhs);
-            return *this;
-        }
-
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename Sequence>
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list&
@@ -100,6 +110,16 @@ namespace boost { namespace fusion
             inherited_type::operator=(rhs);
             return *this;
         }
+#else
+        template <typename Sequence>
+        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        list&
+        operator=(Sequence&& rhs)
+        {
+            inherited_type::operator=(std::forward<Sequence>(rhs));
+            return *this;
+        }
+#endif
     };
 }}
 

--- a/include/boost/fusion/container/list/list.hpp
+++ b/include/boost/fusion/container/list/list.hpp
@@ -1,5 +1,5 @@
 /*=============================================================================
-    Copyright (c) 2014 Kohei Takahashi
+    Copyright (c) 2014-2015 Kohei Takahashi
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -33,10 +33,9 @@ namespace boost { namespace fusion
     {
     private:
         typedef detail::list_to_cons<> list_to_cons;
-
-    public:
         typedef list_to_cons::type inherited_type;
 
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}
@@ -62,10 +61,9 @@ namespace boost { namespace fusion
     {
     private:
         typedef detail::list_to_cons<T...> list_to_cons;
-
-    public:
         typedef typename list_to_cons::type inherited_type;
 
+    public:
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}

--- a/include/boost/fusion/container/list/list.hpp
+++ b/include/boost/fusion/container/list/list.hpp
@@ -13,6 +13,97 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Without variadics, we will use the PP version
 ///////////////////////////////////////////////////////////////////////////////
+#if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
 # include <boost/fusion/container/list/detail/cpp03/list.hpp>
+#else
 
+///////////////////////////////////////////////////////////////////////////////
+// C++11 interface
+///////////////////////////////////////////////////////////////////////////////
+#include <boost/fusion/container/list/detail/list_to_cons.hpp>
+
+namespace boost { namespace fusion
+{
+    struct nil_;
+    struct void_;
+
+    template <>
+    struct list<>
+        : detail::list_to_cons<>::type
+    {
+    private:
+        typedef detail::list_to_cons<> list_to_cons;
+
+    public:
+        typedef list_to_cons::type inherited_type;
+
+        BOOST_FUSION_GPU_ENABLED
+        list()
+            : inherited_type() {}
+
+        template <typename Sequence>
+        BOOST_FUSION_GPU_ENABLED
+        list(Sequence const& rhs)
+            : inherited_type(rhs) {}
+
+        template <typename Sequence>
+        BOOST_FUSION_GPU_ENABLED
+        list&
+        operator=(Sequence const& rhs)
+        {
+            inherited_type::operator=(rhs);
+            return *this;
+        }
+    };
+
+    template <typename ...T>
+    struct list
+        : detail::list_to_cons<T...>::type
+    {
+    private:
+        typedef detail::list_to_cons<T...> list_to_cons;
+
+    public:
+        typedef typename list_to_cons::type inherited_type;
+
+        BOOST_FUSION_GPU_ENABLED
+        list()
+            : inherited_type() {}
+
+        template <typename ...U>
+        BOOST_FUSION_GPU_ENABLED
+        list(list<U...> const& rhs)
+            : inherited_type(rhs) {}
+
+        template <typename Sequence>
+        BOOST_FUSION_GPU_ENABLED
+        list(Sequence const& rhs)
+            : inherited_type(rhs) {}
+
+        BOOST_FUSION_GPU_ENABLED
+        explicit
+        list(typename detail::call_param<T>::type ...args)
+            : inherited_type(list_to_cons::call(args...)) {}
+
+        template <typename ...U>
+        BOOST_FUSION_GPU_ENABLED
+        list&
+        operator=(list<U...> const& rhs)
+        {
+            inherited_type::operator=(rhs);
+            return *this;
+        }
+
+        template <typename Sequence>
+        BOOST_FUSION_GPU_ENABLED
+        list&
+        operator=(Sequence const& rhs)
+        {
+            inherited_type::operator=(rhs);
+            return *this;
+        }
+    };
+}}
+
+#endif
 #endif

--- a/include/boost/fusion/container/list/list.hpp
+++ b/include/boost/fusion/container/list/list.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace fusion
     public:
         typedef list_to_cons::type inherited_type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}
 
@@ -47,7 +47,7 @@ namespace boost { namespace fusion
             : inherited_type(rhs) {}
 
         template <typename Sequence>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list&
         operator=(Sequence const& rhs)
         {
@@ -66,12 +66,12 @@ namespace boost { namespace fusion
     public:
         typedef typename list_to_cons::type inherited_type;
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list()
             : inherited_type() {}
 
         template <typename ...U>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list(list<U...> const& rhs)
             : inherited_type(rhs) {}
 
@@ -80,13 +80,13 @@ namespace boost { namespace fusion
         list(Sequence const& rhs)
             : inherited_type(rhs) {}
 
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit
         list(typename detail::call_param<T>::type ...args)
             : inherited_type(list_to_cons::call(args...)) {}
 
         template <typename ...U>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list&
         operator=(list<U...> const& rhs)
         {
@@ -95,7 +95,7 @@ namespace boost { namespace fusion
         }
 
         template <typename Sequence>
-        BOOST_FUSION_GPU_ENABLED
+        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         list&
         operator=(Sequence const& rhs)
         {

--- a/include/boost/fusion/container/list/list_fwd.hpp
+++ b/include/boost/fusion/container/list/list_fwd.hpp
@@ -10,9 +10,34 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/config.hpp>
 
+#if  defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) \
+  || (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
+# if defined(BOOST_FUSION_HAS_VARIADIC_LIST)
+#   undef BOOST_FUSION_HAS_VARIADIC_LIST
+# endif
+#else
+# if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
+#   define BOOST_FUSION_HAS_VARIADIC_LIST
+# endif
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // With no variadics, we will use the C++03 version
 ///////////////////////////////////////////////////////////////////////////////
+#if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
 # include <boost/fusion/container/list/detail/cpp03/list_fwd.hpp>
+#else
 
+///////////////////////////////////////////////////////////////////////////////
+// C++11 interface
+///////////////////////////////////////////////////////////////////////////////
+namespace boost { namespace fusion
+{
+    struct void_;
+
+    template <typename ...T>
+    struct list;
+}}
+
+#endif
 #endif


### PR DESCRIPTION
As mentioned in #57, this implementation doesn't support move.
I'll fix it until 1.59 release.