### PR TITLE
Feature/no bounds sequence

### DIFF
--- a/doc/fusion.qbk
+++ b/doc/fusion.qbk
@@ -79,6 +79,7 @@
 [def __bidirectional_iterator__ [link fusion.iterator.concepts.bidirectional_iterator Bidirectional Iterator]]
 [def __random_access_iterator__ [link fusion.iterator.concepts.random_access_iterator Random Access Iterator]]
 [def __associative_iterator__   [link fusion.iterator.concepts.associative_iterator Associative Iterator]]
+[def __no_bounds_iterator__     [link fusion.iterator.concepts.no_bounds_iterator No-bounds Iterator]]
 
 [def __next__                   [link fusion.iterator.functions.next `next`]]
 [def __prior__                  [link fusion.iterator.functions.prior `prior`]]
@@ -108,6 +109,7 @@
 [def __bidirectional_sequence__ [link fusion.sequence.concepts.bidirectional_sequence Bidirectional Sequence]]
 [def __random_access_sequence__ [link fusion.sequence.concepts.random_access_sequence Random Access Sequence]]
 [def __associative_sequence__   [link fusion.sequence.concepts.associative_sequence Associative Sequence]]
+[def __no_bounds_sequence__     [link fusion.sequence.concepts.no_bounds_sequence No-bounds Sequence]]
 
 [def __containers__             [link fusion.container Container]]
 [def __vector__                 [link fusion.container.vector `vector`]]
@@ -336,6 +338,8 @@
 [def __iterator_facade__        [link fusion.extension.iterator_facade `iterator_facade`]]
 
 [def __adt_attribute_proxy__    [link fusion.notes.adt_attribute_proxy `adt_attribute_proxy`]]
+
+[def __window_function__        [@http://en.wikipedia.org/wiki/Window_function Window Function]]
 
 [include preface.qbk]
 [include introduction.qbk]

--- a/doc/fusion.qbk
+++ b/doc/fusion.qbk
@@ -79,7 +79,7 @@
 [def __bidirectional_iterator__ [link fusion.iterator.concepts.bidirectional_iterator Bidirectional Iterator]]
 [def __random_access_iterator__ [link fusion.iterator.concepts.random_access_iterator Random Access Iterator]]
 [def __associative_iterator__   [link fusion.iterator.concepts.associative_iterator Associative Iterator]]
-[def __no_bounds_iterator__     [link fusion.iterator.concepts.no_bounds_iterator No-bounds Iterator]]
+[def __unbounded_iterator__     [link fusion.iterator.concepts.unbounded_iterator Unbounded Iterator]]
 
 [def __next__                   [link fusion.iterator.functions.next `next`]]
 [def __prior__                  [link fusion.iterator.functions.prior `prior`]]
@@ -109,7 +109,7 @@
 [def __bidirectional_sequence__ [link fusion.sequence.concepts.bidirectional_sequence Bidirectional Sequence]]
 [def __random_access_sequence__ [link fusion.sequence.concepts.random_access_sequence Random Access Sequence]]
 [def __associative_sequence__   [link fusion.sequence.concepts.associative_sequence Associative Sequence]]
-[def __no_bounds_sequence__     [link fusion.sequence.concepts.no_bounds_sequence No-bounds Sequence]]
+[def __unbounded_sequence__     [link fusion.sequence.concepts.unbounded_sequence Unbounded Sequence]]
 
 [def __containers__             [link fusion.container Container]]
 [def __vector__                 [link fusion.container.vector `vector`]]

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -69,6 +69,8 @@
         Access Iterator</a></span></dt>
 <dt><span class="section"><a href="fusion/iterator/concepts/associative_iterator.html">Associative
         Iterator</a></span></dt>
+<dt><span class="section"><a href="fusion/iterator/concepts/no_bounds_iterator.html">No-bounds
+        Iterator</a></span></dt>
 </dl></dd>
 <dt><span class="section"><a href="fusion/iterator/functions.html">Functions</a></span></dt>
 <dd><dl>
@@ -115,6 +117,8 @@
 <dt><span class="section"><a href="fusion/sequence/concepts/random_access_sequence.html">Random
         Access Sequence</a></span></dt>
 <dt><span class="section"><a href="fusion/sequence/concepts/associative_sequence.html">Associative
+        Sequence</a></span></dt>
+<dt><span class="section"><a href="fusion/sequence/concepts/no_bounds_sequence.html">No-bounds
         Sequence</a></span></dt>
 </dl></dd>
 <dt><span class="section"><a href="fusion/sequence/intrinsic.html">Intrinsic</a></span></dt>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -69,7 +69,7 @@
         Access Iterator</a></span></dt>
 <dt><span class="section"><a href="fusion/iterator/concepts/associative_iterator.html">Associative
         Iterator</a></span></dt>
-<dt><span class="section"><a href="fusion/iterator/concepts/no_bounds_iterator.html">No-bounds
+<dt><span class="section"><a href="fusion/iterator/concepts/unbounded_iterator.html">Unbounded
         Iterator</a></span></dt>
 </dl></dd>
 <dt><span class="section"><a href="fusion/iterator/functions.html">Functions</a></span></dt>
@@ -118,7 +118,7 @@
         Access Sequence</a></span></dt>
 <dt><span class="section"><a href="fusion/sequence/concepts/associative_sequence.html">Associative
         Sequence</a></span></dt>
-<dt><span class="section"><a href="fusion/sequence/concepts/no_bounds_sequence.html">No-bounds
+<dt><span class="section"><a href="fusion/sequence/concepts/unbounded_sequence.html">Unbounded
         Sequence</a></span></dt>
 </dl></dd>
 <dt><span class="section"><a href="fusion/sequence/intrinsic.html">Intrinsic</a></span></dt>
@@ -278,7 +278,7 @@
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: May 10, 2013 at 05:54:18 GMT</small></p></td>
+<td align="left"><p><small>Last revised: June 25, 2015 at 13:41:27 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/iterator.qbk
+++ b/doc/iterator.qbk
@@ -257,9 +257,9 @@ expressions must be valid:
 
 [endsect]
 
-[section No-bounds Iterator]
+[section Unbounded Iterator]
 
-[warning In this release, __no_bounds_iterator__ concept has no effect. It's reserved for future release.]
+[warning In this release, __unbounded_iterator__ concept has no effect. It's reserved for future release.]
 
 [endsect]
 

--- a/doc/iterator.qbk
+++ b/doc/iterator.qbk
@@ -257,6 +257,12 @@ expressions must be valid:
 
 [endsect]
 
+[section No-bounds Iterator]
+
+[warning In this release, __no_bounds_iterator__ concept has no effect. It's reserved for future release.]
+
+[endsect]
+
 [endsect]
 
 [section Functions]

--- a/doc/sequence.qbk
+++ b/doc/sequence.qbk
@@ -41,8 +41,8 @@ Sequence allows efficient retrieval of elements based on keys.
 
 [heading Boundary]
 
-The __no_bounds_sequence__ concept is also orthogonal to traversal and associativity.
-A No-bounds Sequence allows out-of-bounds access.
+The __unbounded_sequence__ concept is also orthogonal to traversal and associativity.
+A Unbounded Sequence allows out-of-bounds access.
 
 [section Forward Sequence]
 
@@ -364,11 +364,11 @@ you can use `__result_of_value_at_key__<S, K>`.]
 
 [endsect]
 
-[section No-bounds Sequence]
+[section Unbounded Sequence]
 
 [heading Description]
 
-A No-bounds Sequence allows Out-of-Bounds access: it will achieve something like a __window_function__.
+A Unbounded Sequence allows Out-of-Bounds access: it will achieve something like a __window_function__.
 Most of the sequences do not meet this concept, but some special usecases do.
 
 [important User extending sequences should handle any parameters or be SFINAE-friendly.]
@@ -740,7 +740,7 @@ element from the beginning of the sequence, is a valid expression. Else,
 returns a type convertible to the M-th element from the beginning of the
 sequence.
 
-[*Precondition]: `0 <= M::value < __size__(seq)` (where `seq` is not __no_bounds_sequence__)
+[*Precondition]: `0 <= M::value < __size__(seq)` (where `seq` is not __unbounded_sequence__)
 
 [*Semantics]: Equivalent to
 
@@ -793,7 +793,7 @@ element from the beginning of the sequence, is a valid expression. Else,
 returns a type convertible to the N-th element from the beginning of the
 sequence.
 
-[*Precondition]: `0 <= N < __size__(seq)` (where `seq` is not __no_bounds_sequence__)
+[*Precondition]: `0 <= N < __size__(seq)` (where `seq` is not __unbounded_sequence__)
 
 [*Semantics]: Equivalent to
 
@@ -887,7 +887,7 @@ the sequence `seq` if `seq` is mutable and `e = o`, where `e` is the
 element associated with Key, is a valid expression. Else, returns a type
 convertible to the element associated with Key.
 
-[*Precondition]: `has_key<Key>(seq) == true` (where `seq` is not __no_bounds_sequence__)
+[*Precondition]: `has_key<Key>(seq) == true` (where `seq` is not __unbounded_sequence__)
 
 [*Semantics]: Returns the element associated with Key.
 
@@ -1203,7 +1203,7 @@ the actual element type, use __result_of_value_at__].
 
 [*Return type]: Any type.
 
-[*Precondition]: `0 <= M::value < __result_of_size__<Seq>::value` (where `Seq` is not __no_bounds_sequence__)
+[*Precondition]: `0 <= M::value < __result_of_size__<Seq>::value` (where `Seq` is not __unbounded_sequence__)
 
 [*Semantics]: Returns the result type of using __at__ to access the `M`th element of `Seq`.
 
@@ -1247,7 +1247,7 @@ get the actual element type, use __result_of_value_at_c__].
 
 [*Return type]: Any type
 
-[*Precondition]: `0 <= N < __result_of_size__<Seq>::value` (where `Seq` is not __no_bounds_sequence__)
+[*Precondition]: `0 <= N < __result_of_size__<Seq>::value` (where `Seq` is not __unbounded_sequence__)
 
 [*Semantics]: Returns the result type of using __at_c__ to access the `N`th element of `Seq`.
 
@@ -1408,7 +1408,7 @@ you want to get the actual element type, use __result_of_value_at_key__].
 
 [*Return type]: Any type.
 
-[*Precondition]: `has_key<Seq, Key>::type::value == true` (where `Seq` is not __no_bounds_sequence__)
+[*Precondition]: `has_key<Seq, Key>::type::value == true` (where `Seq` is not __unbounded_sequence__)
 
 [*Semantics]: Returns the result of using __at_key__ to access the element with key type `Key` in `Seq`.
 
@@ -1448,7 +1448,7 @@ Returns the actual element type associated with a Key from the __sequence__.
 
 [*Return type]: Any type.
 
-[*Precondition]: `has_key<Seq, Key>::type::value == true` (where `Seq` is not __no_bounds_sequence__)
+[*Precondition]: `has_key<Seq, Key>::type::value == true` (where `Seq` is not __unbounded_sequence__)
 
 [*Semantics]: Returns the actual element type associated with key type
 `Key` in `Seq`.

--- a/doc/sequence.qbk
+++ b/doc/sequence.qbk
@@ -39,6 +39,11 @@ These concepts pertain to sequence traversal.
 The __associative_sequence__ concept is orthogonal to traversal. An Associative
 Sequence allows efficient retrieval of elements based on keys.
 
+[heading Boundary]
+
+The __no_bounds_sequence__ concept is also orthogonal to traversal and associativity.
+A No-bounds Sequence allows out-of-bounds access.
+
 [section Forward Sequence]
 
 [heading Description]
@@ -356,6 +361,55 @@ you can use `__result_of_value_at_key__<S, K>`.]
 * __iterator_range__ (where adapted iterators are __associative_iterator__\ s)
 * __joint_view__     (where adapted sequences are __associative_sequence__\ s and __forward_sequence__\ s)
 * __reverse_view__   (where adapted sequence is an __associative_sequence__ and a __bidirectional_sequence__)
+
+[endsect]
+
+[section No-bounds Sequence]
+
+[heading Description]
+
+A No-bounds Sequence allows Out-of-Bounds access: it will achieve something like a __window_function__.
+Most of the sequences do not meet this concept, but some special usecases do.
+
+[important User extending sequences should handle any parameters or be SFINAE-friendly.]
+
+[variablelist Notation
+    [[`s`]       [An Fusion Sequence]]
+    [[`S`]       [An Fusion Sequence type]]
+    [[`M`]       [An __mpl__ integral constant]]
+    [[`N`]       [An integral constant]]
+    [[`K`]       [An arbitrary /key/ type]]
+    [[`o`]       [An arbitrary object]]
+    [[`e`]       [A Sequence element]]
+]
+
+[heading Valid Expressions]
+
+[table
+    [[Expression]               [Return type]   [Type Requirements]                         [Runtime Complexity]]
+    [[`__at_c__<N>(s)`]         [Any type]      []                                          [Depends on its traversability]]
+    [[`__at_c__<N>(s) = o`]     [Any type]      []                                          [Depends on its traversability]]
+    [[`__at__<M>(s)`]           [Any type]      []                                          [Depends on its traversability]]
+    [[`__at__<M>(s) = o`]       [Any type]      []                                          [Depends on its traversability]]
+    [[`__at_key__<K>(s)`]       [Any type]      [`S` should be __associative_sequence__]    [Depends on its traversability]]
+    [[`__at_key__<K>(s) = o`]   [Any type]      [`S` should be __associative_sequence__]    [Depends on its traversability]]
+]
+
+[heading Result Type Expressions]
+
+[table
+    [[Expression]                               [Compile Time Complexity]]
+    [[`__result_of_at__<S, M>::type`]           [Depends on its traversability]]
+    [[`__result_of_at_c__<S, N>::type`]         [Depends on its traversability]]
+    [[`__result_of_value_at__<S, M>::type`]     [Depends on its traversability]]
+    [[`__result_of_value_at_c__<S, N>::type`]   [Depends on its traversability]]
+    [[`__result_of_at_key__<S, K>::type`]       [Depends on its traversability]]
+    [[`__result_of_value_at_key__<S, K>::type`] [Depends on its traversability]]
+]
+
+[heading Models]
+
+* none.
 
 [endsect]
 
@@ -686,7 +740,7 @@ element from the beginning of the sequence, is a valid expression. Else,
 returns a type convertible to the M-th element from the beginning of the
 sequence.
 
-[*Precondition]: `0 <= M::value < __size__(s)`
+[*Precondition]: `0 <= M::value < __size__(seq)` (where `seq` is not __no_bounds_sequence__)
 
 [*Semantics]: Equivalent to
 
@@ -739,7 +793,7 @@ element from the beginning of the sequence, is a valid expression. Else,
 returns a type convertible to the N-th element from the beginning of the
 sequence.
 
-[*Precondition]: `0 <= N < __size__(s)`
+[*Precondition]: `0 <= N < __size__(seq)` (where `seq` is not __no_bounds_sequence__)
 
 [*Semantics]: Equivalent to
 
@@ -833,7 +887,7 @@ the sequence `seq` if `seq` is mutable and `e = o`, where `e` is the
 element associated with Key, is a valid expression. Else, returns a type
 convertible to the element associated with Key.
 
-[*Precondition]: `has_key<Key>(seq) == true`
+[*Precondition]: `has_key<Key>(seq) == true` (where `seq` is not __no_bounds_sequence__)
 
 [*Semantics]: Returns the element associated with Key.
 
@@ -1149,6 +1203,8 @@ the actual element type, use __result_of_value_at__].
 
 [*Return type]: Any type.
 
+[*Precondition]: `0 <= M::value < __result_of_size__<Seq>::value` (where `Seq` is not __no_bounds_sequence__)
+
 [*Semantics]: Returns the result type of using __at__ to access the `M`th element of `Seq`.
 
 [heading Header]
@@ -1190,6 +1246,8 @@ get the actual element type, use __result_of_value_at_c__].
     result_of::at_c<Seq, N>::type
 
 [*Return type]: Any type
+
+[*Precondition]: `0 <= N < __result_of_size__<Seq>::value` (where `Seq` is not __no_bounds_sequence__)
 
 [*Semantics]: Returns the result type of using __at_c__ to access the `N`th element of `Seq`.
 
@@ -1350,6 +1408,8 @@ you want to get the actual element type, use __result_of_value_at_key__].
 
 [*Return type]: Any type.
 
+[*Precondition]: `has_key<Seq, Key>::type::value == true` (where `Seq` is not __no_bounds_sequence__)
+
 [*Semantics]: Returns the result of using __at_key__ to access the element with key type `Key` in `Seq`.
 
 [heading Header]
@@ -1387,6 +1447,8 @@ Returns the actual element type associated with a Key from the __sequence__.
     result_of::value_at_key<Seq, Key>::type
 
 [*Return type]: Any type.
+
+[*Precondition]: `has_key<Seq, Key>::type::value == true` (where `Seq` is not __no_bounds_sequence__)
 
 [*Semantics]: Returns the actual element type associated with key type
 `Key` in `Seq`.

--- a/doc/support.qbk
+++ b/doc/support.qbk
@@ -228,7 +228,7 @@ And optionally from:
         {
             struct associative_tag {};
 
-            struct no_bounds_tag {};
+            struct unbounded_tag {};
         }}
 
 [*Semantics]: Establishes the conceptual classification of a particular

--- a/doc/support.qbk
+++ b/doc/support.qbk
@@ -227,6 +227,8 @@ And optionally from:
         namespace boost { namespace fusion
         {
             struct associative_tag {};
+
+            struct no_bounds_tag {};
         }}
 
 [*Semantics]: Establishes the conceptual classification of a particular

--- a/include/boost/fusion/sequence/intrinsic/at.hpp
+++ b/include/boost/fusion/sequence/intrinsic/at.hpp
@@ -67,7 +67,7 @@ namespace boost { namespace fusion
             : mpl::if_<
                   mpl::or_<
                       mpl::less<N, typename extension::size_impl<Tag>::template apply<Sequence>::type>
-                    , traits::has_no_bounds<Sequence>
+                    , traits::is_unbounded<Sequence>
                   >
                 , typename extension::at_impl<Tag>::template apply<Sequence, N>
                 , mpl::empty_base

--- a/include/boost/fusion/sequence/intrinsic/at.hpp
+++ b/include/boost/fusion/sequence/intrinsic/at.hpp
@@ -10,12 +10,13 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/mpl/int.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
 #include <boost/mpl/less.hpp>
 #include <boost/mpl/empty_base.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/fusion/sequence/intrinsic_fwd.hpp>
 #include <boost/fusion/support/tag_of.hpp>
-#include <boost/fusion/support/detail/access.hpp>
+#include <boost/fusion/support/category_of.hpp>
 
 namespace boost { namespace fusion
 {
@@ -64,7 +65,10 @@ namespace boost { namespace fusion
         template <typename Sequence, typename N, typename Tag>
         struct at_impl
             : mpl::if_<
-                  mpl::less<N, typename extension::size_impl<Tag>::template apply<Sequence>::type>
+                  mpl::or_<
+                      mpl::less<N, typename extension::size_impl<Tag>::template apply<Sequence>::type>
+                    , traits::has_no_bounds<Sequence>
+                  >
                 , typename extension::at_impl<Tag>::template apply<Sequence, N>
                 , mpl::empty_base
               >::type

--- a/include/boost/fusion/sequence/intrinsic/at_key.hpp
+++ b/include/boost/fusion/sequence/intrinsic/at_key.hpp
@@ -76,7 +76,7 @@ namespace boost { namespace fusion
             : mpl::if_<
                   mpl::or_<
                       typename extension::has_key_impl<Tag>::template apply<Sequence, Key>
-                    , traits::has_no_bounds<Sequence>
+                    , traits::is_unbounded<Sequence>
                   >
                 , typename extension::at_key_impl<Tag>::template apply<Sequence, Key>
                 , mpl::empty_base

--- a/include/boost/fusion/sequence/intrinsic/at_key.hpp
+++ b/include/boost/fusion/sequence/intrinsic/at_key.hpp
@@ -11,10 +11,15 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/fusion/sequence/intrinsic_fwd.hpp>
+#include <boost/fusion/sequence/intrinsic/has_key.hpp>
 #include <boost/fusion/algorithm/query/find.hpp>
 #include <boost/fusion/iterator/deref_data.hpp>
 #include <boost/fusion/support/tag_of.hpp>
+#include <boost/fusion/support/category_of.hpp>
 #include <boost/fusion/support/detail/access.hpp>
+#include <boost/mpl/empty_base.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
 
 namespace boost { namespace fusion
 {
@@ -64,12 +69,26 @@ namespace boost { namespace fusion
         struct at_key_impl<std_pair_tag>;
     }
 
+    namespace detail
+    {
+        template <typename Sequence, typename Key, typename Tag>
+        struct at_key_impl
+            : mpl::if_<
+                  mpl::or_<
+                      typename extension::has_key_impl<Tag>::template apply<Sequence, Key>
+                    , traits::has_no_bounds<Sequence>
+                  >
+                , typename extension::at_key_impl<Tag>::template apply<Sequence, Key>
+                , mpl::empty_base
+              >::type
+        {};
+    }
+
     namespace result_of
     {
         template <typename Sequence, typename Key>
         struct at_key
-            : extension::at_key_impl<typename detail::tag_of<Sequence>::type>::
-                template apply<Sequence, Key>
+            : detail::at_key_impl<Sequence, Key, typename detail::tag_of<Sequence>::type>
         {};
     }
 

--- a/include/boost/fusion/sequence/intrinsic/value_at.hpp
+++ b/include/boost/fusion/sequence/intrinsic/value_at.hpp
@@ -9,8 +9,13 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/mpl/int.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/less.hpp>
+#include <boost/mpl/empty_base.hpp>
 #include <boost/fusion/sequence/intrinsic_fwd.hpp>
 #include <boost/fusion/support/tag_of.hpp>
+#include <boost/fusion/support/category_of.hpp>
 
 namespace boost { namespace fusion
 {
@@ -50,12 +55,26 @@ namespace boost { namespace fusion
         struct value_at_impl<std_pair_tag>;
     }
 
+    namespace detail
+    {
+        template <typename Sequence, typename N, typename Tag>
+        struct value_at_impl
+            : mpl::if_<
+                  mpl::or_<
+                      mpl::less<N, typename extension::size_impl<Tag>::template apply<Sequence>::type>
+                    , traits::has_no_bounds<Sequence>
+                  >
+                , typename extension::value_at_impl<Tag>::template apply<Sequence, N>
+                , mpl::empty_base
+              >::type
+        {};
+    }
+
     namespace result_of
     {
         template <typename Sequence, typename N>
         struct value_at
-            : extension::value_at_impl<typename detail::tag_of<Sequence>::type>::
-                template apply<Sequence, N>
+            : detail::value_at_impl<Sequence, N, typename detail::tag_of<Sequence>::type>
         {};
 
         template <typename Sequence, int N>

--- a/include/boost/fusion/sequence/intrinsic/value_at.hpp
+++ b/include/boost/fusion/sequence/intrinsic/value_at.hpp
@@ -62,7 +62,7 @@ namespace boost { namespace fusion
             : mpl::if_<
                   mpl::or_<
                       mpl::less<N, typename extension::size_impl<Tag>::template apply<Sequence>::type>
-                    , traits::has_no_bounds<Sequence>
+                    , traits::is_unbounded<Sequence>
                   >
                 , typename extension::value_at_impl<Tag>::template apply<Sequence, N>
                 , mpl::empty_base

--- a/include/boost/fusion/sequence/intrinsic/value_at_key.hpp
+++ b/include/boost/fusion/sequence/intrinsic/value_at_key.hpp
@@ -10,10 +10,15 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/mpl/int.hpp>
+#include <boost/mpl/empty_base.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
 #include <boost/fusion/sequence/intrinsic_fwd.hpp>
+#include <boost/fusion/sequence/intrinsic/has_key.hpp>
 #include <boost/fusion/iterator/value_of_data.hpp>
 #include <boost/fusion/algorithm/query/find.hpp>
 #include <boost/fusion/support/tag_of.hpp>
+#include <boost/fusion/support/category_of.hpp>
 
 namespace boost { namespace fusion
 {
@@ -52,13 +57,27 @@ namespace boost { namespace fusion
         template <>
         struct value_at_key_impl<std_pair_tag>;
     }
-    
+
+    namespace detail
+    {
+        template <typename Sequence, typename N, typename Tag>
+        struct value_at_key_impl
+            : mpl::if_<
+                  mpl::or_<
+                      typename extension::has_key_impl<Tag>::template apply<Sequence, N>
+                    , traits::has_no_bounds<Sequence>
+                  >
+                , typename extension::value_at_key_impl<Tag>::template apply<Sequence, N>
+                , mpl::empty_base
+              >::type
+        {};
+    }
+
     namespace result_of
     {
         template <typename Sequence, typename N>
         struct value_at_key
-            : extension::value_at_key_impl<typename detail::tag_of<Sequence>::type>::
-                template apply<Sequence, N>
+            : detail::value_at_key_impl<Sequence, N, typename detail::tag_of<Sequence>::type>
         {};
     }
 }}

--- a/include/boost/fusion/sequence/intrinsic/value_at_key.hpp
+++ b/include/boost/fusion/sequence/intrinsic/value_at_key.hpp
@@ -65,7 +65,7 @@ namespace boost { namespace fusion
             : mpl::if_<
                   mpl::or_<
                       typename extension::has_key_impl<Tag>::template apply<Sequence, N>
-                    , traits::has_no_bounds<Sequence>
+                    , traits::is_unbounded<Sequence>
                   >
                 , typename extension::value_at_key_impl<Tag>::template apply<Sequence, N>
                 , mpl::empty_base

--- a/include/boost/fusion/support/category_of.hpp
+++ b/include/boost/fusion/support/category_of.hpp
@@ -36,7 +36,7 @@ namespace boost { namespace fusion
 
     struct associative_tag {};
 
-    struct no_bounds_tag {};
+    struct unbounded_tag {};
 
     namespace extension
     {
@@ -111,9 +111,9 @@ namespace boost { namespace fusion
         {};
 
         template <typename T>
-        struct has_no_bounds
+        struct is_unbounded
             : is_base_of<
-                no_bounds_tag
+                unbounded_tag
               , typename category_of<T>::type>
         {};
     }

--- a/include/boost/fusion/support/category_of.hpp
+++ b/include/boost/fusion/support/category_of.hpp
@@ -36,6 +36,8 @@ namespace boost { namespace fusion
 
     struct associative_tag {};
 
+    struct no_bounds_tag {};
+
     namespace extension
     {
         template<typename Tag>
@@ -105,6 +107,13 @@ namespace boost { namespace fusion
         struct is_random_access
             : is_base_of<
                 random_access_traversal_tag
+              , typename category_of<T>::type>
+        {};
+
+        template <typename T>
+        struct has_no_bounds
+            : is_base_of<
+                no_bounds_tag
               , typename category_of<T>::type>
         {};
     }


### PR DESCRIPTION
Relating to https://github.com/boostorg/fusion/commit/c9ae4fc8869faace8eaec797c9c6d90328832f25, introducing `no_bounds_tag` to be able to out-of-bounds access, like
```cpp
static_assert(result_of::size<NoboundsUserSequence>::value < 10, "");
result_of::at_c<NoboundsUserSequence, 10>::type // no error
```

@jfalcou and @K-ballo, feel free to comment.

Note: This PR is independent from variadics PRs.
