### PR TITLE
Prevent use of conversion ctor  for copy purpose.

### DIFF
--- a/include/boost/fusion/container/list/cons.hpp
+++ b/include/boost/fusion/container/list/cons.hpp
@@ -23,6 +23,7 @@
 #include <boost/fusion/container/list/detail/value_at_impl.hpp>
 #include <boost/fusion/container/list/detail/empty_impl.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_traits/is_base_of.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
@@ -79,6 +80,7 @@ namespace boost { namespace fusion
           , typename boost::enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
+                  , mpl::not_<is_base_of<cons, Sequence> >
                   , mpl::not_<is_convertible<Sequence, Car> > > // use copy to car instead
             >::type* /*dummy*/ = 0
         )


### PR DESCRIPTION
Some compilers elect conversion ctor for copy purpose in implicitly defined copy ctor with derived class.

It will fix: [graph - mcgregor_subgraphs_test / msvc-10.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08c-win2012R2-64on64-boost-bin-v2-libs-graph-test-mcgregor_subgraphs_test-test-msvc-10-0-dbg-adrs-mdl-64-thrd-mlt.html), [graph - vf2_sub_graph_iso_test / msvc-10.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08c-win2012R2-64on64-boost-bin-v2-libs-graph-test-vf2_sub_graph_iso_test-test-msvc-10-0-dbg-adrs-mdl-64-thrd-mlt.html) and so on ...

see: http://lists.boost.org/boost-users/2015/06/84496.php