### PR TITLE
Fix a issue with nested fusion::tuple.

### DIFF
--- a/include/boost/fusion/tuple/detail/tuple.hpp
+++ b/include/boost/fusion/tuple/detail/tuple.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace fusion
             : base_type() {}
 
         BOOST_FUSION_GPU_ENABLED tuple(tuple const& rhs)
-            : base_type(rhs) {}
+            : base_type(static_cast<base_type const&>(rhs)) {}
 
         template <typename U1, typename U2>
         BOOST_FUSION_GPU_ENABLED
@@ -72,7 +72,7 @@ namespace boost { namespace fusion
         BOOST_FUSION_GPU_ENABLED
         tuple& operator=(tuple const& rhs)
         {
-            base_type::operator=(rhs);
+            base_type::operator=(static_cast<base_type const&>(rhs));
             return *this;
         }
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -121,6 +121,7 @@ project
     [ run sequence/tuple_make.cpp :  :  :  : ]
     [ run sequence/tuple_misc.cpp :  :  :  : ]
     [ run sequence/tuple_mutate.cpp :  :  :  : ]
+    [ run sequence/tuple_nest.cpp :  :  :  : ]
     [ run sequence/tuple_hash.cpp :  :  :  : ]
     [ run sequence/tuple_tie.cpp :  :  :  : ]
     [ run sequence/transform_view.cpp :  :  :  : ]

--- a/test/sequence/tuple_nest.cpp
+++ b/test/sequence/tuple_nest.cpp
@@ -1,0 +1,19 @@
+/*=============================================================================
+    Copyright (C) 2015 Kohei Takahshi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/tuple/tuple.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#define FUSION_SEQUENCE tuple
+#include "nest.hpp"
+
+int
+main()
+{
+    test();
+    return boost::report_errors();
+}
+


### PR DESCRIPTION
This is same as #92 , but for master branch (i.e. for 1.59.0 release).