### PR TITLE
Fix #11517 (for master)

### DIFF
--- a/include/boost/fusion/container/generation/ignore.hpp
+++ b/include/boost/fusion/container/generation/ignore.hpp
@@ -27,7 +27,7 @@ namespace boost { namespace fusion
     }
 
     //  "ignore" allows tuple positions to be ignored when using "tie".
-    BOOST_CONSTEXPR detail::swallow_assign const ignore = detail::swallow_assign();
+    BOOST_CONSTEXPR_OR_CONST detail::swallow_assign ignore = detail::swallow_assign();
 }}
 
 #endif

--- a/include/boost/fusion/container/generation/ignore.hpp
+++ b/include/boost/fusion/container/generation/ignore.hpp
@@ -9,6 +9,8 @@
 #if !defined(FUSION_IGNORE_07192005_0329)
 #define FUSION_IGNORE_07192005_0329
 
+#include <boost/fusion/support/config.hpp>
+
 namespace boost { namespace fusion
 {
     //  Swallows any assignment (by Doug Gregor)
@@ -17,7 +19,7 @@ namespace boost { namespace fusion
         struct swallow_assign
         {
             template<typename T>
-            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+            BOOST_FUSION_CONSTEXPR_THIS BOOST_FUSION_GPU_ENABLED
             swallow_assign const&
             operator=(const T&) const
             {

--- a/include/boost/fusion/support/config.hpp
+++ b/include/boost/fusion/support/config.hpp
@@ -88,4 +88,12 @@ namespace std
 }
 #endif
 
+
+// Workaround for older GCC that doesn't accept `this` in constexpr.
+#if BOOST_WORKAROUND(BOOST_GCC, < 40700)
+#define BOOST_FUSION_CONSTEXPR_THIS
+#else
+#define BOOST_FUSION_CONSTEXPR_THIS BOOST_CONSTEXPR
+#endif
+
 #endif

--- a/include/boost/fusion/support/unused.hpp
+++ b/include/boost/fusion/support/unused.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace fusion
         }
 
         template <typename T>
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_CONSTEXPR_THIS BOOST_FUSION_GPU_ENABLED
         unused_type const&
         operator=(T const&) const BOOST_NOEXCEPT
         {
@@ -49,7 +49,7 @@ namespace boost { namespace fusion
             return *this;
         }
 
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_FUSION_CONSTEXPR_THIS BOOST_FUSION_GPU_ENABLED
         unused_type const&
         operator=(unused_type const&) const BOOST_NOEXCEPT
         {

--- a/include/boost/fusion/support/unused.hpp
+++ b/include/boost/fusion/support/unused.hpp
@@ -64,7 +64,7 @@ namespace boost { namespace fusion
         }
     };
 
-    BOOST_CONSTEXPR unused_type const unused = unused_type();
+    BOOST_CONSTEXPR_OR_CONST unused_type unused = unused_type();
 
     namespace detail
     {


### PR DESCRIPTION
It is good for 1.59 release sine some regression runner have passed without regression.

Note: Same as #96.