### PR TITLE
Suppress some warnings.

### DIFF
--- a/include/boost/fusion/algorithm/transformation/flatten.hpp
+++ b/include/boost/fusion/algorithm/transformation/flatten.hpp
@@ -1,9 +1,9 @@
-/*//////////////////////////////////////////////////////////////////////////////
+/*==============================================================================
     Copyright (c) 2013 Jamboree
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//////////////////////////////////////////////////////////////////////////////*/
+==============================================================================*/
 #ifndef BOOST_FUSION_ALGORITHM_FLATTEN_HPP_INCLUDED
 #define BOOST_FUSION_ALGORITHM_FLATTEN_HPP_INCLUDED
 

--- a/include/boost/fusion/view/flatten_view.hpp
+++ b/include/boost/fusion/view/flatten_view.hpp
@@ -1,9 +1,9 @@
-/*//////////////////////////////////////////////////////////////////////////////
+/*==============================================================================
     Copyright (c) 2013 Jamboree
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//////////////////////////////////////////////////////////////////////////////*/
+==============================================================================*/
 #ifndef BOOST_FUSION_SEQUENCE_FLATTEN_VIEW_HPP_INCLUDED
 #define BOOST_FUSION_SEQUENCE_FLATTEN_VIEW_HPP_INCLUDED
 

--- a/include/boost/fusion/view/flatten_view/flatten_view.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view.hpp
@@ -1,9 +1,9 @@
-/*//////////////////////////////////////////////////////////////////////////////
+/*==============================================================================
     Copyright (c) 2013 Jamboree
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//////////////////////////////////////////////////////////////////////////////*/
+==============================================================================*/
 #ifndef BOOST_FUSION_FLATTEN_VIEW_HPP_INCLUDED
 #define BOOST_FUSION_FLATTEN_VIEW_HPP_INCLUDED
 

--- a/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
@@ -1,9 +1,9 @@
-/*//////////////////////////////////////////////////////////////////////////////
+/*==============================================================================
     Copyright (c) 2013 Jamboree
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//////////////////////////////////////////////////////////////////////////////*/
+==============================================================================*/
 #ifndef BOOST_FUSION_FLATTEN_VIEW_ITERATOR_HPP_INCLUDED
 #define BOOST_FUSION_FLATTEN_VIEW_ITERATOR_HPP_INCLUDED
 

--- a/test/algorithm/flatten.cpp
+++ b/test/algorithm/flatten.cpp
@@ -1,9 +1,9 @@
-/*//////////////////////////////////////////////////////////////////////////////
+/*==============================================================================
     Copyright (c) 2013 Jamboree
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//////////////////////////////////////////////////////////////////////////////*/
+==============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/fusion/container/vector/vector.hpp>
 #include <boost/fusion/sequence/io/out.hpp>

--- a/test/algorithm/pop_back.cpp
+++ b/test/algorithm/pop_back.cpp
@@ -88,6 +88,7 @@ main()
         auto i1 = find<int>(popv);
         auto i2 = find<double>(pop);
 
+        (void)push;
         BOOST_TEST(i1 != end(pop));
         BOOST_TEST(i2 != end(pop));
         BOOST_TEST(i1 != i2);

--- a/test/sequence/flatten_view.cpp
+++ b/test/sequence/flatten_view.cpp
@@ -1,9 +1,9 @@
-/*//////////////////////////////////////////////////////////////////////////////
+/*==============================================================================
     Copyright (c) 2013 Jamboree
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//////////////////////////////////////////////////////////////////////////////*/
+==============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/fusion/container/vector/vector.hpp>
 #include <boost/fusion/view/flatten_view/flatten_view.hpp>


### PR DESCRIPTION
This will fix [Warnings: GLIS-homo-impi - fusion / intel-linux](http://www.boost.org/development/tests/develop/output/GLIS-homo-impi-fusion-intel-linux-warnings.html) and [Warnings: Flast-FreeBSD10-clang~gnu++11 - fusion / clang-linux-3.4.1](http://www.boost.org/development/tests/develop/output/Flast-FreeBSD10-clang~gnu++11-fusion-clang-linux-3-4-1-warnings.html).