### PR TITLE
Compliant container-wide requirements.

### DIFF
--- a/include/boost/fusion/container/generation/make_set.hpp
+++ b/include/boost/fusion/container/generation/make_set.hpp
@@ -19,6 +19,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <boost/fusion/support/detail/as_fusion_element.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <utility>
 
 namespace boost { namespace fusion
 {
@@ -27,16 +30,22 @@ namespace boost { namespace fusion
         template <typename ...T>
         struct make_set
         {
-            typedef set<typename detail::as_fusion_element<T>::type...> type;
+            typedef set<
+                typename detail::as_fusion_element<
+                    typename remove_const<
+                        typename remove_reference<T>::type
+                    >::type
+                >::type...
+            > type;
         };
     }
 
     template <typename ...T>
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::make_set<T...>::type
-    make_set(T const&... arg)
+    make_set(T&&... arg)
     {
-        return typename result_of::make_set<T...>::type(arg...);
+        return typename result_of::make_set<T...>::type(std::forward<T>(arg)...);
     }
  }}
 

--- a/include/boost/fusion/container/set/set.hpp
+++ b/include/boost/fusion/container/set/set.hpp
@@ -97,39 +97,20 @@ namespace boost { namespace fusion
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
-        set(Sequence const& rhs)
-            : data(rhs) {}
-
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-        template <typename Sequence>
-        BOOST_FUSION_GPU_ENABLED
         set(Sequence&& rhs)
             : data(std::forward<Sequence>(rhs)) {}
-#endif
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit
         set(typename detail::call_param<T>::type ...args)
             : data(args...) {}
 
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename ...U>
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit
         set(U&& ...args)
             : data(std::forward<U>(args)...) {}
-#endif
 
-        template <typename U>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        set&
-        operator=(U const& rhs)
-        {
-            data = rhs;
-            return *this;
-        }
-
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename U>
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set&
@@ -138,7 +119,6 @@ namespace boost { namespace fusion
             data = std::forward<U>(rhs);
             return *this;
         }
-#endif
 
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         storage_type& get_data() { return data; }

--- a/include/boost/fusion/container/set/set.hpp
+++ b/include/boost/fusion/container/set/set.hpp
@@ -23,6 +23,8 @@
 #include <boost/fusion/support/detail/access.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
+#include <boost/fusion/support/is_sequence.hpp>
+#include <boost/fusion/support/detail/is_same_size.hpp>
 #include <boost/fusion/container/vector/vector.hpp>
 #include <boost/fusion/container/set/detail/begin_impl.hpp>
 #include <boost/fusion/container/set/detail/end_impl.hpp>
@@ -31,8 +33,8 @@
 #include <boost/fusion/container/set/detail/deref_impl.hpp>
 #include <boost/fusion/container/set/detail/key_of_impl.hpp>
 #include <boost/fusion/container/set/detail/value_of_data_impl.hpp>
-#include <boost/mpl/identity.hpp>
 #include <boost/mpl/bool.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost { namespace fusion
 {
@@ -57,7 +59,9 @@ namespace boost { namespace fusion
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
-        set(Sequence const& rhs)
+        set(Sequence const& rhs,
+            typename enable_if<traits::is_sequence<Sequence> >::type* = 0,
+            typename enable_if<detail::is_same_size<Sequence, storage_type> >::type* = 0)
             : data(rhs) {}
 
         template <typename T>
@@ -97,7 +101,9 @@ namespace boost { namespace fusion
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
-        set(Sequence&& rhs)
+        set(Sequence&& rhs,
+            typename enable_if<traits::is_sequence<Sequence> >::type* = 0,
+            typename enable_if<detail::is_same_size<Sequence, storage_type> >::type* = 0)
             : data(std::forward<Sequence>(rhs)) {}
 
         template <typename ...U>

--- a/include/boost/fusion/container/set/set.hpp
+++ b/include/boost/fusion/container/set/set.hpp
@@ -100,13 +100,8 @@ namespace boost { namespace fusion
         set(Sequence&& rhs)
             : data(std::forward<Sequence>(rhs)) {}
 
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        explicit
-        set(typename detail::call_param<T>::type ...args)
-            : data(args...) {}
-
         template <typename ...U>
-        BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit
         set(U&& ...args)
             : data(std::forward<U>(args)...) {}

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -66,12 +66,12 @@ namespace boost { namespace fusion
         template <typename This, typename ...T>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         inline each_elem
-        dispatch( T const&... ) BOOST_NOEXCEPT { return each_elem(); }
+        dispatch(T const&...) BOOST_NOEXCEPT { return each_elem(); }
 
         template <typename This>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         inline copy_or_move
-        dispatch( This const& ) BOOST_NOEXCEPT { return copy_or_move(); }
+        dispatch(This const&) BOOST_NOEXCEPT { return copy_or_move(); }
 
         template <typename This, typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
@@ -82,7 +82,7 @@ namespace boost { namespace fusion
               , make_indices_from_seq<Sequence>
             >::type
         >
-        dispatch( Sequence const& ) BOOST_NOEXCEPT
+        dispatch(Sequence const&) BOOST_NOEXCEPT
         { return from_sequence<typename make_indices_from_seq<Sequence>::type>(); }
 
 

--- a/include/boost/fusion/support/detail/is_same_size.hpp
+++ b/include/boost/fusion/support/detail/is_same_size.hpp
@@ -1,0 +1,29 @@
+/*=============================================================================
+    Copyright (c) 2014-2015 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#ifndef FUSION_IS_SAME_SIZE_10082015_1156
+#define FUSION_IS_SAME_SIZE_10082015_1156
+
+#include <boost/fusion/support/is_sequence.hpp>
+#include <boost/fusion/sequence/intrinsic/size.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/equal_to.hpp>
+
+namespace boost { namespace fusion { namespace detail
+{
+    template <typename Sequence1, typename Sequence2, typename = void, typename = void>
+    struct is_same_size : mpl::false_ {};
+
+    template <typename Sequence1, typename Sequence2>
+    struct is_same_size<Sequence1, Sequence2,
+                        typename enable_if<traits::is_sequence<Sequence1> >::type,
+                        typename enable_if<traits::is_sequence<Sequence2> >::type>
+        : mpl::equal_to<result_of::size<Sequence1>, result_of::size<Sequence2> >
+    {};
+}}}
+
+#endif


### PR DESCRIPTION
As discussed in #105, drop some redundant special functions, and use universal references for generators.