### PR TITLE
Fix fusion::at<vector<...>, N> for C array types

### DIFF
--- a/include/boost/fusion/container/vector/detail/value_at_impl.hpp
+++ b/include/boost/fusion/container/vector/detail/value_at_impl.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace fusion
             struct apply
             {
                 typedef typename boost::remove_cv<Sequence>::type seq;
-                typedef typename decltype(seq::template value_at_impl<N::value>(boost::declval<seq*>()))::type type;
+                typedef typename mpl::identity<decltype(seq::template value_at_impl<N::value>(boost::declval<seq*>()))>::type::type type;
             };
         };
     }

--- a/include/boost/fusion/container/vector/detail/value_at_impl.hpp
+++ b/include/boost/fusion/container/vector/detail/value_at_impl.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace fusion
             struct apply
             {
                 typedef typename boost::remove_cv<Sequence>::type seq;
-                typedef decltype(seq::template value_at_impl<N::value>(boost::declval<seq*>())) type;
+                typedef typename decltype(seq::template value_at_impl<N::value>(boost::declval<seq*>()))::type type;
             };
         };
     }

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -272,7 +272,7 @@ namespace boost { namespace fusion
 
             template <std::size_t N, typename U>
             static BOOST_FUSION_GPU_ENABLED
-            U value_at_impl(store<N, U>*);
+            mpl::identity<U> value_at_impl(store<N, U>*);
         };
 
         template <typename V, typename... T>


### PR DESCRIPTION
Hi there,

It seems that implementing fast `value_at` for vectors breaks compatibility with types that cannot be returned from functions. The following example does not work anymore after this [commit](https://github.com/boostorg/fusion/commit/1ad2e59e072d726abe3dad78fe130af19c1445b8).

```c++
#include <boost/fusion/container.hpp>
#include <iostream>

using seq = boost::fusion::vector<float[4]>;
using res = boost::fusion::result_of::value_at<seq, boost::mpl::int_<0>>::type;

int main(int argc, char **argv) {
  return 0;
}
```

My fix still uses the O(1) implementation and restore compatibility with those kind of types.
Let me know if something is wrong with that PR!


