### PR TITLE
Fix fusion::fold regression with MSVC 8.

### DIFF
--- a/include/boost/fusion/algorithm/iteration/detail/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/fold.hpp
@@ -100,9 +100,9 @@ FUSION_HASH endif
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<SeqSize,It,State,F
           , typename boost::enable_if_has_type<
 #if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
-FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, == 1500)
+FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, >= 1500)
 #endif
-#if BOOST_WORKAROUND(BOOST_MSVC, == 1500) || \
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1500) || \
     (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
                 // Following SFINAE enables to avoid MSVC 9's partial specialization
                 // ambiguous bug but MSVC 8 don't compile, and moreover MSVC 8 style

--- a/include/boost/fusion/algorithm/iteration/detail/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/fold.hpp
@@ -42,6 +42,12 @@
 #   define BOOST_FUSION_FOLD_IMPL_INVOKE_IT_TRANSFORM(IT) fusion::deref(IT)
 #endif
 
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+#   define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+#else
+#   define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+#endif
+
 namespace boost { namespace fusion
 {
     namespace detail
@@ -57,7 +63,7 @@ namespace boost { namespace fusion
 
         template<typename It, typename State, typename F>
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<0,It,State,F
-          , typename boost::enable_if_has_type<typename State::type>::type
+          , typename boost::enable_if_has_type<BOOST_FUSION_FOLD_IMPL_ENABLER(State)>::type
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
           , true
 #endif
@@ -75,7 +81,7 @@ namespace boost { namespace fusion
                 // workaround won't work with MSVC 9.
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
 #else
-                typename State::type
+                BOOST_FUSION_FOLD_IMPL_ENABLER(State)
 #endif
             >::type
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
@@ -236,6 +242,7 @@ namespace boost { namespace fusion
 }}
 
 #undef BOOST_FUSION_FOLD_NAME
+#undef BOOST_FUSION_FOLD_IMPL_ENABLER
 #undef BOOST_FUSION_FOLD_IMPL_FIRST_IT_FUNCTION
 #undef BOOST_FUSION_FOLD_IMPL_NEXT_IT_FUNCTION
 #undef BOOST_FUSION_FOLD_IMPL_FIRST_IT_META_TRANSFORM

--- a/include/boost/fusion/algorithm/iteration/detail/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/fold.hpp
@@ -9,6 +9,8 @@
 ==============================================================================*/
 #include <boost/preprocessor/cat.hpp>
 
+#define FUSION_HASH #
+
 #ifdef BOOST_FUSION_REVERSE_FOLD
 #   ifdef BOOST_FUSION_ITER_FOLD
 #       define BOOST_FUSION_FOLD_NAME reverse_iter_fold
@@ -42,10 +44,18 @@
 #   define BOOST_FUSION_FOLD_IMPL_INVOKE_IT_TRANSFORM(IT) fusion::deref(IT)
 #endif
 
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
-#   define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+#if (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
+FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, < 1500)
+FUSION_HASH     define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+FUSION_HASH else
+FUSION_HASH     define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+FUSION_HASH endif
 #else
-#   define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+#   if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+#       define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+#   else
+#       define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+#   endif
 #endif
 
 namespace boost { namespace fusion
@@ -53,9 +63,16 @@ namespace boost { namespace fusion
     namespace detail
     {
         template<int SeqSize, typename It, typename State, typename F, typename = void
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, < 1500)
+#endif
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500) || \
+    (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
           // Dirty hack: those compilers cannot choose exactly one partial specialization.
           , bool = SeqSize == 0
+#endif
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH endif
 #endif
         >
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)
@@ -64,8 +81,15 @@ namespace boost { namespace fusion
         template<typename It, typename State, typename F>
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<0,It,State,F
           , typename boost::enable_if_has_type<BOOST_FUSION_FOLD_IMPL_ENABLER(State)>::type
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, < 1500)
+#endif
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500) || \
+    (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
           , true
+#endif
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH endif
 #endif
           >
         {
@@ -75,17 +99,35 @@ namespace boost { namespace fusion
         template<int SeqSize, typename It, typename State, typename F>
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<SeqSize,It,State,F
           , typename boost::enable_if_has_type<
-#if BOOST_WORKAROUND(BOOST_MSVC, == 1500)
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, == 1500)
+#endif
+#if BOOST_WORKAROUND(BOOST_MSVC, == 1500) || \
+    (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
                 // Following SFINAE enables to avoid MSVC 9's partial specialization
                 // ambiguous bug but MSVC 8 don't compile, and moreover MSVC 8 style
                 // workaround won't work with MSVC 9.
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH else
+                BOOST_FUSION_FOLD_IMPL_ENABLER(State)
+#endif
 #else
                 BOOST_FUSION_FOLD_IMPL_ENABLER(State)
 #endif
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH endif
+#endif
             >::type
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH if BOOST_WORKAROUND BOOST_PREVENT_MACRO_SUBSTITUTION (BOOST_MSVC, < 1500)
+#endif
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500) || \
+    (defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES))
           , false
+#endif
+#if defined(__WAVE__) && defined(BOOST_FUSION_CREATE_PREPROCESSED_FILES)
+FUSION_HASH endif
 #endif
           >
           : BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<
@@ -249,3 +291,4 @@ namespace boost { namespace fusion
 #undef BOOST_FUSION_FOLD_IMPL_FIRST_IT_TRANSFORM
 #undef BOOST_FUSION_FOLD_IMPL_INVOKE_IT_META_TRANSFORM
 #undef BOOST_FUSION_FOLD_IMPL_INVOKE_IT_TRANSFORM
+#undef FUSION_HASH

--- a/include/boost/fusion/algorithm/iteration/detail/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/fold.hpp
@@ -46,23 +46,42 @@ namespace boost { namespace fusion
 {
     namespace detail
     {
-        template<int SeqSize, typename It, typename State, typename F, typename = void>
+        template<int SeqSize, typename It, typename State, typename F, typename = void
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+          // Dirty hack: those compilers cannot choose exactly one partial specialization.
+          , bool = SeqSize == 0
+#endif
+        >
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)
         {};
 
         template<typename It, typename State, typename F>
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<0,It,State,F
-          , typename boost::enable_if_has_type<typename State::type>::type>
+          , typename boost::enable_if_has_type<typename State::type>::type
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+          , true
+#endif
+          >
         {
             typedef typename State::type type;
         };
 
         template<int SeqSize, typename It, typename State, typename F>
         struct BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<SeqSize,It,State,F
-            // MSVC9 issues a compile error as a partial specialization is ambiguous.
           , typename boost::enable_if_has_type<
+#if BOOST_WORKAROUND(BOOST_MSVC, == 1500)
+                // Following SFINAE enables to avoid MSVC 9's partial specialization
+                // ambiguous bug but MSVC 8 don't compile, and moreover MSVC 8 style
+                // workaround won't work with MSVC 9.
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
-            >::type>
+#else
+                typename State::type
+#endif
+            >::type
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
+          , false
+#endif
+          >
           : BOOST_PP_CAT(result_of_it_,BOOST_FUSION_FOLD_NAME)<
                 SeqSize-1
               , typename result_of::BOOST_FUSION_FOLD_IMPL_NEXT_IT_FUNCTION<It>::type

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/fold.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace fusion
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_fold<SeqSize,It,State,F
           , typename boost::enable_if_has_type<
-# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+# if BOOST_WORKAROUND (BOOST_MSVC, >= 1500)
                 
                 
                 

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/fold.hpp
@@ -8,25 +8,49 @@
 
     This is an auto-generated file. Do not edit!
 ==============================================================================*/
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+# else
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+# endif
 namespace boost { namespace fusion
 {
     namespace detail
     {
-        template<int SeqSize, typename It, typename State, typename F, typename = void>
+        template<int SeqSize, typename It, typename State, typename F, typename = void
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          
+          , bool = SeqSize == 0
+# endif
+        >
         struct result_of_it_fold
         {};
         template<typename It, typename State, typename F>
         struct result_of_it_fold<0,It,State,F
-          , typename boost::enable_if_has_type<typename State::type>::type>
+          , typename boost::enable_if_has_type<BOOST_FUSION_FOLD_IMPL_ENABLER(State)>::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , true
+# endif
+          >
         {
             typedef typename State::type type;
         };
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_fold<SeqSize,It,State,F
-            
           , typename boost::enable_if_has_type<
+# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+                
+                
+                
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
-            >::type>
+# else
+                BOOST_FUSION_FOLD_IMPL_ENABLER(State)
+# endif
+            >::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , false
+# endif
+          >
           : result_of_it_fold<
                 SeqSize-1
               , typename result_of::next<It>::type

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/iter_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/iter_fold.hpp
@@ -7,25 +7,49 @@
 
     This is an auto-generated file. Do not edit!
 ==============================================================================*/
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+# else
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+# endif
 namespace boost { namespace fusion
 {
     namespace detail
     {
-        template<int SeqSize, typename It, typename State, typename F, typename = void>
+        template<int SeqSize, typename It, typename State, typename F, typename = void
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          
+          , bool = SeqSize == 0
+# endif
+        >
         struct result_of_it_iter_fold
         {};
         template<typename It, typename State, typename F>
         struct result_of_it_iter_fold<0,It,State,F
-          , typename boost::enable_if_has_type<typename State::type>::type>
+          , typename boost::enable_if_has_type<BOOST_FUSION_FOLD_IMPL_ENABLER(State)>::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , true
+# endif
+          >
         {
             typedef typename State::type type;
         };
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_iter_fold<SeqSize,It,State,F
-            
           , typename boost::enable_if_has_type<
+# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+                
+                
+                
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
-            >::type>
+# else
+                BOOST_FUSION_FOLD_IMPL_ENABLER(State)
+# endif
+            >::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , false
+# endif
+          >
           : result_of_it_iter_fold<
                 SeqSize-1
               , typename result_of::next<It>::type

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/iter_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/iter_fold.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace fusion
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_iter_fold<SeqSize,It,State,F
           , typename boost::enable_if_has_type<
-# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+# if BOOST_WORKAROUND (BOOST_MSVC, >= 1500)
                 
                 
                 

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_fold.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace fusion
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_reverse_fold<SeqSize,It,State,F
           , typename boost::enable_if_has_type<
-# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+# if BOOST_WORKAROUND (BOOST_MSVC, >= 1500)
                 
                 
                 

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_fold.hpp
@@ -7,25 +7,49 @@
 
     This is an auto-generated file. Do not edit!
 ==============================================================================*/
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+# else
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+# endif
 namespace boost { namespace fusion
 {
     namespace detail
     {
-        template<int SeqSize, typename It, typename State, typename F, typename = void>
+        template<int SeqSize, typename It, typename State, typename F, typename = void
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          
+          , bool = SeqSize == 0
+# endif
+        >
         struct result_of_it_reverse_fold
         {};
         template<typename It, typename State, typename F>
         struct result_of_it_reverse_fold<0,It,State,F
-          , typename boost::enable_if_has_type<typename State::type>::type>
+          , typename boost::enable_if_has_type<BOOST_FUSION_FOLD_IMPL_ENABLER(State)>::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , true
+# endif
+          >
         {
             typedef typename State::type type;
         };
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_reverse_fold<SeqSize,It,State,F
-            
           , typename boost::enable_if_has_type<
+# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+                
+                
+                
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
-            >::type>
+# else
+                BOOST_FUSION_FOLD_IMPL_ENABLER(State)
+# endif
+            >::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , false
+# endif
+          >
           : result_of_it_reverse_fold<
                 SeqSize-1
               , typename result_of::prior<It>::type

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_iter_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_iter_fold.hpp
@@ -7,25 +7,49 @@
 
     This is an auto-generated file. Do not edit!
 ==============================================================================*/
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) void
+# else
+# define BOOST_FUSION_FOLD_IMPL_ENABLER(T) typename T::type
+# endif
 namespace boost { namespace fusion
 {
     namespace detail
     {
-        template<int SeqSize, typename It, typename State, typename F, typename = void>
+        template<int SeqSize, typename It, typename State, typename F, typename = void
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          
+          , bool = SeqSize == 0
+# endif
+        >
         struct result_of_it_reverse_iter_fold
         {};
         template<typename It, typename State, typename F>
         struct result_of_it_reverse_iter_fold<0,It,State,F
-          , typename boost::enable_if_has_type<typename State::type>::type>
+          , typename boost::enable_if_has_type<BOOST_FUSION_FOLD_IMPL_ENABLER(State)>::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , true
+# endif
+          >
         {
             typedef typename State::type type;
         };
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_reverse_iter_fold<SeqSize,It,State,F
-            
           , typename boost::enable_if_has_type<
+# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+                
+                
+                
                 typename boost::disable_if_c<SeqSize == 0, State>::type::type
-            >::type>
+# else
+                BOOST_FUSION_FOLD_IMPL_ENABLER(State)
+# endif
+            >::type
+# if BOOST_WORKAROUND (BOOST_MSVC, < 1500)
+          , false
+# endif
+          >
           : result_of_it_reverse_iter_fold<
                 SeqSize-1
               , typename result_of::prior<It>::type

--- a/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_iter_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/preprocessed/reverse_iter_fold.hpp
@@ -37,7 +37,7 @@ namespace boost { namespace fusion
         template<int SeqSize, typename It, typename State, typename F>
         struct result_of_it_reverse_iter_fold<SeqSize,It,State,F
           , typename boost::enable_if_has_type<
-# if BOOST_WORKAROUND (BOOST_MSVC, == 1500)
+# if BOOST_WORKAROUND (BOOST_MSVC, >= 1500)
                 
                 
                 


### PR DESCRIPTION
This PR will fix [fusion - fold / msvc-8.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08a-win2012R2-64on64-boost-bin-v2-libs-fusion-test-fold-test-msvc-8-0-dbg-adrs-mdl-64-thrd-mlt.html) and many other similar failures.