### PR TITLE
error: reference to 'ws' is ambiguous

### DIFF
--- a/include/boost/fusion/sequence/io/detail/manip.hpp
+++ b/include/boost/fusion/sequence/io/detail/manip.hpp
@@ -110,8 +110,7 @@ namespace boost { namespace fusion
             {
                 // read a delimiter
                 string_type const* p = stream_data_t::get(stream);
-                using namespace std;
-                ws(stream);
+                std::ws(stream);
 
                 if (p)
                 {


### PR DESCRIPTION
Upon including a file that declares a namespace `::ws`, `GCC` would no longer compile due to the error given above.  This little fix solves the issue.