### PR TITLE
Fix ambiguous ctor, close #11766

### DIFF
--- a/include/boost/fusion/algorithm/transformation/zip.hpp
+++ b/include/boost/fusion/algorithm/transformation/zip.hpp
@@ -17,6 +17,7 @@
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/preprocessor/repetition/enum.hpp>
 #include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_params_with_a_default.hpp>
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 #include <boost/preprocessor/arithmetic/inc.hpp>

--- a/include/boost/fusion/container/deque/deque.hpp
+++ b/include/boost/fusion/container/deque/deque.hpp
@@ -21,6 +21,7 @@
 // C++11 interface
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/support/sequence_base.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/support/detail/access.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/container/deque/detail/keyed_element.hpp>
@@ -59,7 +60,7 @@ namespace boost { namespace fusion
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence>>>::type* /*dummy*/ = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence>>, void_>::type = void_()) BOOST_NOEXCEPT
         {}
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
@@ -149,8 +150,8 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit deque(Sequence const& seq
-          , typename disable_if<is_convertible<Sequence, Head> >::type* /*dummy*/ = 0
-          , typename enable_if<traits::is_sequence<Sequence> >::type* /*dummy*/ = 0)
+          , typename disable_if<is_convertible<Sequence, Head>, void_>::type = void_()
+          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
           : base(base::from_iterator(fusion::begin(seq)))
         {}
 

--- a/include/boost/fusion/container/deque/deque.hpp
+++ b/include/boost/fusion/container/deque/deque.hpp
@@ -22,6 +22,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/support/detail/access.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/container/deque/detail/keyed_element.hpp>
@@ -60,7 +61,7 @@ namespace boost { namespace fusion
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence>>, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence>>, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
@@ -150,8 +151,8 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         explicit deque(Sequence const& seq
-          , typename disable_if<is_convertible<Sequence, Head>, void_>::type = void_()
-          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+          , typename disable_if<is_convertible<Sequence, Head>, detail::enabler_>::type = detail::enabler
+          , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
           : base(base::from_iterator(fusion::begin(seq)))
         {}
 

--- a/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
@@ -102,8 +102,8 @@ namespace boost { namespace fusion {
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0> >::type* /*dummy*/ = 0
-            , typename enable_if<traits::is_sequence<Sequence> >::type* /*dummy*/ = 0)
+            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
+            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : base(base::from_iterator(fusion::begin(seq)))
             {}
 
@@ -133,7 +133,7 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0> >::type* /*dummy*/ = 0
+          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
          )
             : base(BOOST_FUSION_FWD_ELEM(T0_, t0), detail::nil_keyed_element())
             {}
@@ -146,7 +146,8 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         deque(deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>&& seq
             , typename disable_if<
                   is_convertible<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>, T0>
-              >::type* /*dummy*/ = 0)
+                , void_
+              >::type = void_())
             : base(std::forward<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>>(seq))
             {}
         template <typename T>
@@ -180,7 +181,7 @@ FUSION_HASH endif
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> > >::type* /*dummy*/ = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
         {}
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED

--- a/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/deque.hpp
@@ -35,6 +35,7 @@
 #include <boost/mpl/bool.hpp>
 
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #if !defined(BOOST_FUSION_DONT_USE_PREPROCESSED_FILES)
@@ -102,8 +103,8 @@ namespace boost { namespace fusion {
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
-            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename disable_if<is_convertible<Sequence, T0>, detail::enabler_>::type = detail::enabler
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
 
@@ -133,7 +134,7 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
+          , typename enable_if<is_convertible<T0_, T0>, detail::enabler_>::type = detail::enabler
          )
             : base(BOOST_FUSION_FWD_ELEM(T0_, t0), detail::nil_keyed_element())
             {}
@@ -146,8 +147,8 @@ FUSION_HASH if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         deque(deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>&& seq
             , typename disable_if<
                   is_convertible<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>, T0>
-                , void_
-              >::type = void_())
+                , detail::enabler_
+              >::type = detail::enabler)
             : base(std::forward<deque<BOOST_PP_ENUM_PARAMS(FUSION_MAX_DEQUE_SIZE, U)>>(seq))
             {}
         template <typename T>
@@ -181,7 +182,7 @@ FUSION_HASH endif
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque10.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque10.hpp
@@ -202,8 +202,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0> >::type* = 0
-            , typename enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
+            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9>
@@ -226,7 +226,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0> >::type* = 0
+          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -239,7 +239,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9>, T0>
-              >::type* = 0)
+                , void_
+              >::type = void_())
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9>>(seq))
             {}
         template <typename T>
@@ -267,7 +268,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> > >::type* = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque10.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque10.hpp
@@ -202,8 +202,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
-            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename disable_if<is_convertible<Sequence, T0>, detail::enabler_>::type = detail::enabler
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9>
@@ -226,7 +226,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
+          , typename enable_if<is_convertible<T0_, T0>, detail::enabler_>::type = detail::enabler
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -239,8 +239,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9>, T0>
-                , void_
-              >::type = void_())
+                , detail::enabler_
+              >::type = detail::enabler)
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9>>(seq))
             {}
         template <typename T>
@@ -268,7 +268,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque20.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque20.hpp
@@ -382,8 +382,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0> >::type* = 0
-            , typename enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
+            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19>
@@ -406,7 +406,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0> >::type* = 0
+          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -419,7 +419,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19>, T0>
-              >::type* = 0)
+                , void_
+              >::type = void_())
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19>>(seq))
             {}
         template <typename T>
@@ -447,7 +448,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> > >::type* = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque20.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque20.hpp
@@ -382,8 +382,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
-            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename disable_if<is_convertible<Sequence, T0>, detail::enabler_>::type = detail::enabler
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19>
@@ -406,7 +406,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
+          , typename enable_if<is_convertible<T0_, T0>, detail::enabler_>::type = detail::enabler
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -419,8 +419,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19>, T0>
-                , void_
-              >::type = void_())
+                , detail::enabler_
+              >::type = detail::enabler)
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19>>(seq))
             {}
         template <typename T>
@@ -448,7 +448,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque30.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque30.hpp
@@ -562,8 +562,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
-            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename disable_if<is_convertible<Sequence, T0>, detail::enabler_>::type = detail::enabler
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19 , typename U20 , typename U21 , typename U22 , typename U23 , typename U24 , typename U25 , typename U26 , typename U27 , typename U28 , typename U29>
@@ -586,7 +586,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
+          , typename enable_if<is_convertible<T0_, T0>, detail::enabler_>::type = detail::enabler
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -599,8 +599,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29>, T0>
-                , void_
-              >::type = void_())
+                , detail::enabler_
+              >::type = detail::enabler)
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29>>(seq))
             {}
         template <typename T>
@@ -628,7 +628,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque30.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque30.hpp
@@ -562,8 +562,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0> >::type* = 0
-            , typename enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
+            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19 , typename U20 , typename U21 , typename U22 , typename U23 , typename U24 , typename U25 , typename U26 , typename U27 , typename U28 , typename U29>
@@ -586,7 +586,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0> >::type* = 0
+          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -599,7 +599,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29>, T0>
-              >::type* = 0)
+                , void_
+              >::type = void_())
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29>>(seq))
             {}
         template <typename T>
@@ -627,7 +628,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> > >::type* = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque40.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque40.hpp
@@ -742,8 +742,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0> >::type* = 0
-            , typename enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
+            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19 , typename U20 , typename U21 , typename U22 , typename U23 , typename U24 , typename U25 , typename U26 , typename U27 , typename U28 , typename U29 , typename U30 , typename U31 , typename U32 , typename U33 , typename U34 , typename U35 , typename U36 , typename U37 , typename U38 , typename U39>
@@ -766,7 +766,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0> >::type* = 0
+          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -779,7 +779,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39>, T0>
-              >::type* = 0)
+                , void_
+              >::type = void_())
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39>>(seq))
             {}
         template <typename T>
@@ -807,7 +808,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> > >::type* = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque40.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque40.hpp
@@ -742,8 +742,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
-            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename disable_if<is_convertible<Sequence, T0>, detail::enabler_>::type = detail::enabler
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19 , typename U20 , typename U21 , typename U22 , typename U23 , typename U24 , typename U25 , typename U26 , typename U27 , typename U28 , typename U29 , typename U30 , typename U31 , typename U32 , typename U33 , typename U34 , typename U35 , typename U36 , typename U37 , typename U38 , typename U39>
@@ -766,7 +766,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
+          , typename enable_if<is_convertible<T0_, T0>, detail::enabler_>::type = detail::enabler
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -779,8 +779,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39>, T0>
-                , void_
-              >::type = void_())
+                , detail::enabler_
+              >::type = detail::enabler)
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39>>(seq))
             {}
         template <typename T>
@@ -808,7 +808,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque50.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque50.hpp
@@ -922,8 +922,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
-            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename disable_if<is_convertible<Sequence, T0>, detail::enabler_>::type = detail::enabler
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19 , typename U20 , typename U21 , typename U22 , typename U23 , typename U24 , typename U25 , typename U26 , typename U27 , typename U28 , typename U29 , typename U30 , typename U31 , typename U32 , typename U33 , typename U34 , typename U35 , typename U36 , typename U37 , typename U38 , typename U39 , typename U40 , typename U41 , typename U42 , typename U43 , typename U44 , typename U45 , typename U46 , typename U47 , typename U48 , typename U49>
@@ -946,7 +946,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
+          , typename enable_if<is_convertible<T0_, T0>, detail::enabler_>::type = detail::enabler
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -959,8 +959,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39 , U40 , U41 , U42 , U43 , U44 , U45 , U46 , U47 , U48 , U49>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39 , U40 , U41 , U42 , U43 , U44 , U45 , U46 , U47 , U48 , U49>, T0>
-                , void_
-              >::type = void_())
+                , detail::enabler_
+              >::type = detail::enabler)
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39 , U40 , U41 , U42 , U43 , U44 , U45 , U46 , U47 , U48 , U49>>(seq))
             {}
         template <typename T>
@@ -988,7 +988,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, detail::enabler_>::type = detail::enabler) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque50.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/preprocessed/deque50.hpp
@@ -922,8 +922,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template<typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         deque(Sequence const& seq
-            , typename disable_if<is_convertible<Sequence, T0> >::type* = 0
-            , typename enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename disable_if<is_convertible<Sequence, T0>, void_>::type = void_()
+            , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : base(base::from_iterator(fusion::begin(seq)))
             {}
         template <typename U0 , typename U1 , typename U2 , typename U3 , typename U4 , typename U5 , typename U6 , typename U7 , typename U8 , typename U9 , typename U10 , typename U11 , typename U12 , typename U13 , typename U14 , typename U15 , typename U16 , typename U17 , typename U18 , typename U19 , typename U20 , typename U21 , typename U22 , typename U23 , typename U24 , typename U25 , typename U26 , typename U27 , typename U28 , typename U29 , typename U30 , typename U31 , typename U32 , typename U33 , typename U34 , typename U35 , typename U36 , typename U37 , typename U38 , typename U39 , typename U40 , typename U41 , typename U42 , typename U43 , typename U44 , typename U45 , typename U46 , typename U47 , typename U48 , typename U49>
@@ -946,7 +946,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         template <typename T0_>
         BOOST_FUSION_GPU_ENABLED
         explicit deque(T0_&& t0
-          , typename enable_if<is_convertible<T0_, T0> >::type* = 0
+          , typename enable_if<is_convertible<T0_, T0>, void_>::type = void_()
          )
             : base(std::forward<T0_>( t0), detail::nil_keyed_element())
             {}
@@ -959,7 +959,8 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
         deque(deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39 , U40 , U41 , U42 , U43 , U44 , U45 , U46 , U47 , U48 , U49>&& seq
             , typename disable_if<
                   is_convertible<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39 , U40 , U41 , U42 , U43 , U44 , U45 , U46 , U47 , U48 , U49>, T0>
-              >::type* = 0)
+                , void_
+              >::type = void_())
             : base(std::forward<deque<U0 , U1 , U2 , U3 , U4 , U5 , U6 , U7 , U8 , U9 , U10 , U11 , U12 , U13 , U14 , U15 , U16 , U17 , U18 , U19 , U20 , U21 , U22 , U23 , U24 , U25 , U26 , U27 , U28 , U29 , U30 , U31 , U32 , U33 , U34 , U35 , U36 , U37 , U38 , U39 , U40 , U41 , U42 , U43 , U44 , U45 , U46 , U47 , U48 , U49>>(seq))
             {}
         template <typename T>
@@ -987,7 +988,7 @@ deque(T_0 && t0 , T_1 && t1 , T_2 && t2 , T_3 && t3 , T_4 && t4 , T_5 && t5 , T_
             typename enable_if<
                 mpl::and_<
                     traits::is_sequence<Sequence>
-                  , result_of::empty<Sequence> > >::type* = 0) BOOST_NOEXCEPT
+                  , result_of::empty<Sequence> >, void_>::type = void_()) BOOST_NOEXCEPT
         {}
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         deque() BOOST_NOEXCEPT {}

--- a/include/boost/fusion/container/list/cons.hpp
+++ b/include/boost/fusion/container/list/cons.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/container/list/cons_fwd.hpp>
 #include <boost/fusion/support/detail/access.hpp>
 #include <boost/fusion/sequence/intrinsic/begin.hpp>
@@ -82,8 +83,8 @@ namespace boost { namespace fusion
                     traits::is_sequence<Sequence>
                   , mpl::not_<is_base_of<cons, Sequence> >
                   , mpl::not_<is_convertible<Sequence, Car> > > // use copy to car instead
-              , void_
-            >::type = void_()
+              , detail::enabler_
+            >::type = detail::enabler
         )
             : car(*fusion::begin(seq))
             , cdr(fusion::next(fusion::begin(seq)), mpl::true_()) {}

--- a/include/boost/fusion/container/list/cons.hpp
+++ b/include/boost/fusion/container/list/cons.hpp
@@ -9,6 +9,7 @@
 #define FUSION_CONS_07172005_0843
 
 #include <boost/fusion/support/config.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/container/list/cons_fwd.hpp>
 #include <boost/fusion/support/detail/access.hpp>
 #include <boost/fusion/sequence/intrinsic/begin.hpp>
@@ -34,7 +35,6 @@
 
 namespace boost { namespace fusion
 {
-    struct void_;
     struct cons_tag;
     struct forward_traversal_tag;
     struct fusion_sequence_tag;
@@ -82,7 +82,8 @@ namespace boost { namespace fusion
                     traits::is_sequence<Sequence>
                   , mpl::not_<is_base_of<cons, Sequence> >
                   , mpl::not_<is_convertible<Sequence, Car> > > // use copy to car instead
-            >::type* /*dummy*/ = 0
+              , void_
+            >::type = void_()
         )
             : car(*fusion::begin(seq))
             , cdr(fusion::next(fusion::begin(seq)), mpl::true_()) {}

--- a/include/boost/fusion/container/list/detail/cpp03/list.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/list.hpp
@@ -8,6 +8,7 @@
 #define FUSION_LIST_07172005_1153
 
 #include <boost/fusion/support/config.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/container/list/detail/cpp03/list_fwd.hpp>
 #include <boost/fusion/container/list/detail/cpp03/list_to_cons.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
@@ -61,7 +62,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : inherited_type(rhs) {}
 
         //  Expand a couple of forwarding constructors for arguments

--- a/include/boost/fusion/container/list/detail/cpp03/list.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/list.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/container/list/detail/cpp03/list_fwd.hpp>
 #include <boost/fusion/container/list/detail/cpp03/list_to_cons.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
@@ -62,7 +63,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : inherited_type(rhs) {}
 
         //  Expand a couple of forwarding constructors for arguments

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list10.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list10.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list10.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list10.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list20.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list20.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list20.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list20.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list30.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list30.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list30.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list30.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list40.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list40.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list40.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list40.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list50.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list50.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/list/detail/cpp03/preprocessed/list50.hpp
+++ b/include/boost/fusion/container/list/detail/cpp03/preprocessed/list50.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         list(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : inherited_type(rhs) {}
         
         

--- a/include/boost/fusion/container/map/map.hpp
+++ b/include/boost/fusion/container/map/map.hpp
@@ -35,6 +35,7 @@
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
+#include <boost/fusion/support/void.hpp>
 
 #include <boost/utility/enable_if.hpp>
 
@@ -68,21 +69,21 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence const& seq
-          , typename enable_if<traits::is_sequence<Sequence>>::type* /*dummy*/ = 0)
+          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence& seq
-          , typename enable_if<traits::is_sequence<Sequence>>::type* /*dummy*/ = 0)
+          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence&& seq
-          , typename enable_if<traits::is_sequence<Sequence>>::type* /*dummy*/ = 0)
+          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 

--- a/include/boost/fusion/container/map/map.hpp
+++ b/include/boost/fusion/container/map/map.hpp
@@ -36,6 +36,7 @@
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 
 #include <boost/utility/enable_if.hpp>
 
@@ -69,21 +70,21 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence const& seq
-          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+          , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence& seq
-          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+          , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         map(Sequence&& seq
-          , typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+          , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
           : base_type(begin(seq), detail::map_impl_from_iterator())
         {}
 

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set10.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set10.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set10.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set10.hpp
@@ -8,7 +8,6 @@
 ==============================================================================*/
 namespace boost { namespace fusion
 {
-    struct void_;
     struct fusion_sequence_tag;
     template <typename T0 , typename T1 , typename T2 , typename T3 , typename T4 , typename T5 , typename T6 , typename T7 , typename T8 , typename T9>
     struct set : sequence_base<set<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9> >
@@ -27,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set20.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set20.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set20.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set20.hpp
@@ -8,7 +8,6 @@
 ==============================================================================*/
 namespace boost { namespace fusion
 {
-    struct void_;
     struct fusion_sequence_tag;
     template <typename T0 , typename T1 , typename T2 , typename T3 , typename T4 , typename T5 , typename T6 , typename T7 , typename T8 , typename T9 , typename T10 , typename T11 , typename T12 , typename T13 , typename T14 , typename T15 , typename T16 , typename T17 , typename T18 , typename T19>
     struct set : sequence_base<set<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19> >
@@ -27,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set30.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set30.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set30.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set30.hpp
@@ -8,7 +8,6 @@
 ==============================================================================*/
 namespace boost { namespace fusion
 {
-    struct void_;
     struct fusion_sequence_tag;
     template <typename T0 , typename T1 , typename T2 , typename T3 , typename T4 , typename T5 , typename T6 , typename T7 , typename T8 , typename T9 , typename T10 , typename T11 , typename T12 , typename T13 , typename T14 , typename T15 , typename T16 , typename T17 , typename T18 , typename T19 , typename T20 , typename T21 , typename T22 , typename T23 , typename T24 , typename T25 , typename T26 , typename T27 , typename T28 , typename T29>
     struct set : sequence_base<set<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19 , T20 , T21 , T22 , T23 , T24 , T25 , T26 , T27 , T28 , T29> >
@@ -27,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set40.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set40.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set40.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set40.hpp
@@ -8,7 +8,6 @@
 ==============================================================================*/
 namespace boost { namespace fusion
 {
-    struct void_;
     struct fusion_sequence_tag;
     template <typename T0 , typename T1 , typename T2 , typename T3 , typename T4 , typename T5 , typename T6 , typename T7 , typename T8 , typename T9 , typename T10 , typename T11 , typename T12 , typename T13 , typename T14 , typename T15 , typename T16 , typename T17 , typename T18 , typename T19 , typename T20 , typename T21 , typename T22 , typename T23 , typename T24 , typename T25 , typename T26 , typename T27 , typename T28 , typename T29 , typename T30 , typename T31 , typename T32 , typename T33 , typename T34 , typename T35 , typename T36 , typename T37 , typename T38 , typename T39>
     struct set : sequence_base<set<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19 , T20 , T21 , T22 , T23 , T24 , T25 , T26 , T27 , T28 , T29 , T30 , T31 , T32 , T33 , T34 , T35 , T36 , T37 , T38 , T39> >
@@ -27,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set50.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set50.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/preprocessed/set50.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/preprocessed/set50.hpp
@@ -8,7 +8,6 @@
 ==============================================================================*/
 namespace boost { namespace fusion
 {
-    struct void_;
     struct fusion_sequence_tag;
     template <typename T0 , typename T1 , typename T2 , typename T3 , typename T4 , typename T5 , typename T6 , typename T7 , typename T8 , typename T9 , typename T10 , typename T11 , typename T12 , typename T13 , typename T14 , typename T15 , typename T16 , typename T17 , typename T18 , typename T19 , typename T20 , typename T21 , typename T22 , typename T23 , typename T24 , typename T25 , typename T26 , typename T27 , typename T28 , typename T29 , typename T30 , typename T31 , typename T32 , typename T33 , typename T34 , typename T35 , typename T36 , typename T37 , typename T38 , typename T39 , typename T40 , typename T41 , typename T42 , typename T43 , typename T44 , typename T45 , typename T46 , typename T47 , typename T48 , typename T49>
     struct set : sequence_base<set<T0 , T1 , T2 , T3 , T4 , T5 , T6 , T7 , T8 , T9 , T10 , T11 , T12 , T13 , T14 , T15 , T16 , T17 , T18 , T19 , T20 , T21 , T22 , T23 , T24 , T25 , T26 , T27 , T28 , T29 , T30 , T31 , T32 , T33 , T34 , T35 , T36 , T37 , T38 , T39 , T40 , T41 , T42 , T43 , T44 , T45 , T46 , T47 , T48 , T49> >
@@ -27,7 +26,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : data(rhs) {}
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     explicit

--- a/include/boost/fusion/container/set/detail/cpp03/set.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/set.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
@@ -72,7 +73,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            , typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
 
         #include <boost/fusion/container/set/detail/cpp03/set_forward_ctor.hpp>

--- a/include/boost/fusion/container/set/detail/cpp03/set.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/set.hpp
@@ -8,6 +8,7 @@
 #define FUSION_SET_09162005_1104
 
 #include <boost/fusion/support/config.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
@@ -47,7 +48,6 @@
 
 namespace boost { namespace fusion
 {
-    struct void_;
     struct fusion_sequence_tag;
 
     template <BOOST_PP_ENUM_PARAMS(FUSION_MAX_SET_SIZE, typename T)>
@@ -72,7 +72,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs
-            , typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            , typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : data(rhs) {}
 
         #include <boost/fusion/container/set/detail/cpp03/set_forward_ctor.hpp>

--- a/include/boost/fusion/container/set/set.hpp
+++ b/include/boost/fusion/container/set/set.hpp
@@ -21,6 +21,7 @@
 // C++11 interface
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/support/detail/access.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
@@ -60,8 +61,8 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs,
-            typename enable_if<traits::is_sequence<Sequence> >::type* = 0,
-            typename enable_if<detail::is_same_size<Sequence, storage_type> >::type* = 0)
+            typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_(),
+            typename enable_if<detail::is_same_size<Sequence, storage_type>, void_>::type = void_())
             : data(rhs) {}
 
         template <typename T>
@@ -102,8 +103,8 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         set(Sequence&& rhs,
-            typename enable_if<traits::is_sequence<Sequence> >::type* = 0,
-            typename enable_if<detail::is_same_size<Sequence, storage_type> >::type* = 0)
+            typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_(),
+            typename enable_if<detail::is_same_size<Sequence, storage_type>, void_>::type = void_())
             : data(std::forward<Sequence>(rhs)) {}
 
         template <typename ...U>

--- a/include/boost/fusion/container/set/set.hpp
+++ b/include/boost/fusion/container/set/set.hpp
@@ -22,6 +22,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/support/detail/access.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/category_of.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
@@ -61,8 +62,8 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         set(Sequence const& rhs,
-            typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_(),
-            typename enable_if<detail::is_same_size<Sequence, storage_type>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler,
+            typename enable_if<detail::is_same_size<Sequence, storage_type>, detail::enabler_>::type = detail::enabler)
             : data(rhs) {}
 
         template <typename T>
@@ -103,8 +104,8 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         set(Sequence&& rhs,
-            typename enable_if<traits::is_sequence<Sequence>, void_>::type = void_(),
-            typename enable_if<detail::is_same_size<Sequence, storage_type>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler,
+            typename enable_if<detail::is_same_size<Sequence, storage_type>, detail::enabler_>::type = detail::enabler)
             : data(std::forward<Sequence>(rhs)) {}
 
         template <typename ...U>

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector10.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector10.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector10.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector10.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector20.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector20.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector20.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector20.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector30.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector30.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector30.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector30.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector40.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector40.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector40.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector40.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector50.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector50.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector50.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/preprocessed/vvector50.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
         
         

--- a/include/boost/fusion/container/vector/detail/cpp03/vector.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/vector.hpp
@@ -11,6 +11,7 @@
 #include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/fusion/support/config.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/container/vector/vector_fwd.hpp>
 #include <boost/fusion/container/vector/detail/cpp03/vector_n_chooser.hpp>
@@ -118,7 +119,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence> >::type* = 0)
+            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
 
         //  Expand a couple of forwarding constructors for arguments

--- a/include/boost/fusion/container/vector/detail/cpp03/vector.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/vector.hpp
@@ -12,6 +12,7 @@
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/container/vector/vector_fwd.hpp>
 #include <boost/fusion/container/vector/detail/cpp03/vector_n_chooser.hpp>
@@ -119,7 +120,7 @@ namespace boost { namespace fusion
         template <typename Sequence>
         BOOST_FUSION_GPU_ENABLED
         vector(Sequence const& rhs,
-            typename boost::enable_if<traits::is_sequence<Sequence>, void_>::type = void_())
+            typename enable_if<traits::is_sequence<Sequence>, detail::enabler_>::type = detail::enabler)
             : vec(BOOST_FUSION_VECTOR_COPY_INIT()) {}
 
         //  Expand a couple of forwarding constructors for arguments

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -24,6 +24,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
+#include <boost/fusion/support/void.hpp>
 #include <boost/fusion/support/detail/index_sequence.hpp>
 #include <boost/fusion/container/vector/detail/at_impl.hpp>
 #include <boost/fusion/container/vector/detail/value_at_impl.hpp>
@@ -164,7 +165,7 @@ namespace boost { namespace fusion
             template <typename U>
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             store(U&& rhs
-                , typename disable_if<is_same<typename pure<U>::type, store> >::type* = 0)
+                , typename disable_if<is_same<typename pure<U>::type, store>, void_>::type = void_())
                 : elem(std::forward<U>(rhs))
             {}
 

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -25,6 +25,7 @@
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/support/void.hpp>
+#include <boost/fusion/support/detail/enabler.hpp>
 #include <boost/fusion/support/detail/index_sequence.hpp>
 #include <boost/fusion/container/vector/detail/at_impl.hpp>
 #include <boost/fusion/container/vector/detail/value_at_impl.hpp>
@@ -165,7 +166,7 @@ namespace boost { namespace fusion
             template <typename U>
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             store(U&& rhs
-                , typename disable_if<is_same<typename pure<U>::type, store>, void_>::type = void_())
+                , typename disable_if<is_same<typename pure<U>::type, store>, detail::enabler_>::type = detail::enabler)
                 : elem(std::forward<U>(rhs))
             {}
 

--- a/include/boost/fusion/support/detail/enabler.hpp
+++ b/include/boost/fusion/support/detail/enabler.hpp
@@ -1,0 +1,22 @@
+﻿/*=============================================================================
+    Copyright (c) 2015 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#ifndef BOOST_FUSION_SUPPORT_DETAIL_ENABLER_12102015_0346
+#define BOOST_FUSION_SUPPORT_DETAIL_ENABLER_12102015_0346
+
+#include <boost/config.hpp>
+
+namespace boost { namespace fusion { namespace detail
+{
+
+struct enabler_ {};
+BOOST_STATIC_CONSTEXPR enabler_ enabler = {};
+
+}}}
+
+#endif
+


### PR DESCRIPTION
Use `fusion::void_` instead of `void*` in SFINAE expression because it is ambiguous with forwarding ctor if second (and third) element is `void*`.

close [#11766](https://svn.boost.org/trac/boost/ticket/11766)