### PR TITLE
Workaround for ICE on GCC 4.0/4.1.

### DIFF
--- a/include/boost/fusion/view/iterator_range/detail/segmented_iterator_range.hpp
+++ b/include/boost/fusion/view/iterator_range/detail/segmented_iterator_range.hpp
@@ -8,6 +8,7 @@
 #define BOOST_FUSION_SEGMENTED_ITERATOR_RANGE_HPP_INCLUDED
 
 #include <boost/fusion/support/config.hpp>
+#include <boost/detail/workaround.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -409,11 +410,14 @@ namespace boost { namespace fusion { namespace detail
     template <
         typename StackBegin
       , typename StackEnd
-      , bool SameSegment =
-            result_of::equal_to<
+      , bool SameSegment
+#if BOOST_WORKAROUND(BOOST_GCC, < 40000) || BOOST_WORKAROUND(BOOST_GCC, >= 40200)
+          = result_of::equal_to<
                 typename StackBegin::car_type::begin_type
               , typename StackEnd::car_type::begin_type
-            >::type::value>
+            >::type::value
+#endif
+    >
     struct make_segmented_range_reduce2
     {
         typedef
@@ -480,7 +484,14 @@ namespace boost { namespace fusion { namespace detail
 
     template <typename StackBegin, typename StackEnd, int StackBeginSize, int StackEndSize>
     struct make_segmented_range_reduce
-      : make_segmented_range_reduce2<StackBegin, StackEnd>
+      : make_segmented_range_reduce2<StackBegin, StackEnd
+#if BOOST_WORKAROUND(BOOST_GCC, >= 40000) || BOOST_WORKAROUND(BOOST_GCC, < 40200)
+          , result_of::equal_to<
+                typename StackBegin::car_type::begin_type
+              , typename StackEnd::car_type::begin_type
+            >::type::value
+#endif
+        >
     {};
 
     template <typename StackBegin, typename StackEnd>

--- a/include/boost/fusion/view/single_view/detail/next_impl.hpp
+++ b/include/boost/fusion/view/single_view/detail/next_impl.hpp
@@ -39,7 +39,10 @@ namespace boost { namespace fusion
                 static type
                 call(Iterator const& i)
                 {
-                    BOOST_STATIC_ASSERT((type::position::value < 2));
+                    // Workaround for ICE on GCC 4.0.0.
+                    // see https://svn.boost.org/trac/boost/ticket/5808
+                    typedef typename type::position position;
+                    BOOST_STATIC_ASSERT((position::value < 2));
                     return type(i.view);
                 }
             };


### PR DESCRIPTION
close: [#5808](https://svn.boost.org/trac/boost/ticket/5808)

Tested on Fedora Core 4 (!) gcc 4.0.0-8.fc4.x86_64 and Fedora Core 5 gcc 4.1.0-3.fc5.x86_64.