### PR TITLE
Correct workaround condition.

### DIFF
--- a/include/boost/fusion/view/iterator_range/detail/segmented_iterator_range.hpp
+++ b/include/boost/fusion/view/iterator_range/detail/segmented_iterator_range.hpp
@@ -411,7 +411,7 @@ namespace boost { namespace fusion { namespace detail
         typename StackBegin
       , typename StackEnd
       , bool SameSegment
-#if BOOST_WORKAROUND(BOOST_GCC, < 40000) || BOOST_WORKAROUND(BOOST_GCC, >= 40200)
+#if !(BOOST_WORKAROUND(BOOST_GCC, >= 40000) && BOOST_WORKAROUND(BOOST_GCC, < 40200))
           = result_of::equal_to<
                 typename StackBegin::car_type::begin_type
               , typename StackEnd::car_type::begin_type
@@ -485,7 +485,7 @@ namespace boost { namespace fusion { namespace detail
     template <typename StackBegin, typename StackEnd, int StackBeginSize, int StackEndSize>
     struct make_segmented_range_reduce
       : make_segmented_range_reduce2<StackBegin, StackEnd
-#if BOOST_WORKAROUND(BOOST_GCC, >= 40000) || BOOST_WORKAROUND(BOOST_GCC, < 40200)
+#if BOOST_WORKAROUND(BOOST_GCC, >= 40000) && BOOST_WORKAROUND(BOOST_GCC, < 40200)
           , result_of::equal_to<
                 typename StackBegin::car_type::begin_type
               , typename StackEnd::car_type::begin_type


### PR DESCRIPTION
Sorry... It's absolutely my bad on #127 ...

I tested again including non gcc.

- Fedora Core 4 gcc 4.0.0-8.fc4.x86_64
- Fedora Core 5 gcc 4.1.0-3.fc5.x86_64
- Cygwin64 gcc 4.9.3
- MSVC 2013 update 5
