### PR TITLE
Added workaround for GCC 3.4 due to ambiguous.

### DIFF
--- a/include/boost/fusion/sequence/convert.hpp
+++ b/include/boost/fusion/sequence/convert.hpp
@@ -8,6 +8,14 @@
 #define FUSION_CONVERT_10022005_1442
 
 #include <boost/fusion/support/config.hpp>
+#if BOOST_WORKAROUND(BOOST_GCC, < 30500)
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_const.hpp>
+#define BOOST_FUSION_WA_GCC34(type1, type2) \
+    boost::lazy_disable_if<boost::is_const<Sequence>, type1, type2>
+#else
+#define BOOST_FUSION_WA_GCC34(type1, type2) type1, type2
+#endif
 
 namespace boost { namespace fusion
 {
@@ -32,7 +40,7 @@ namespace boost { namespace fusion
 
     template <typename Tag, typename Sequence>
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-    inline typename result_of::convert<Tag, Sequence>::type
+    inline typename BOOST_FUSION_WA_GCC34(result_of::convert<Tag, Sequence>)::type
     convert(Sequence& seq)
     {
         typedef typename result_of::convert<Tag, Sequence>::gen gen;
@@ -49,4 +57,5 @@ namespace boost { namespace fusion
     }
 }}
 
+#undef BOOST_FUSION_WA_GCC34
 #endif


### PR DESCRIPTION
This PR will fix compile failure on GCC 3.4, like [convert_boost_tuple / gcc-mngw-3.4c+](http://www.boost.org/development/tests/develop/developer/output/igaztanaga-gcc-3-4c++03-boost-bin-v2-libs-fusion-test-convert_boost_tuple-test-gcc-mngw-3-4c+-dbg-dbg-symbl-off.html).

- Tested compiler
    - GCC 3.4.2 (Fedora Core 3, gcc-3.4.2-6.fc3.x86_64)
    - GCC 4.9.3 (Cygwin x86_64) gnu++98 / gnu++11 / gnu++14
    - MSVC 12 (VS2013 update5)

NOTE: GCC 3.3 and earlier are not supported officially by Boost community.