### PR TITLE
Added to nested tests, and fixed C++11 vector copy-from-sequence

### DIFF
--- a/test/sequence/nest.hpp
+++ b/test/sequence/nest.hpp
@@ -7,6 +7,43 @@
 
 #include <utility>
 #include <boost/config.hpp>
+#include <boost/fusion/include/as_deque.hpp>
+#include <boost/fusion/include/as_list.hpp>
+#include <boost/fusion/include/as_vector.hpp>
+
+template<typename C, template<typename> class As>
+void test_from_sequence_rvalue()
+{
+    typename As<C>::type dst((C()));
+    (void)dst;
+}
+
+template<typename C, template<typename> class As>
+void test_from_sequence_const_lvalue()
+{
+    C src;
+    typename As<C>::type dst(src);
+    (void)dst;
+}
+
+template<typename C, template<typename> class As>
+void test_from_sequence_lvalue()
+{
+    const C src;
+    typename As<C>::type dst(src);
+    (void)dst;
+}
+
+template<typename C, template<typename> class As>
+void test_from_sequence()
+{
+// the following tests do not work in all cases for C++03
+#if defined(BOOST_FUSION_HAS_VARIADIC_VECTOR)
+    test_from_sequence_rvalue<C, As>();
+    test_from_sequence_const_lvalue<C, As>();
+    test_from_sequence_lvalue<C, As>();
+#endif
+}
 
 template <typename C>
 void test_copy()
@@ -29,6 +66,10 @@ void test_move()
 template <typename C>
 void test_all()
 {
+// as_deque and as_list do not work in C++03 or C++11 mode
+//    test_from_sequence<C, boost::fusion::result_of::as_deque>();
+//    test_from_sequence<C, boost::fusion::result_of::as_list>();
+    test_from_sequence<C, boost::fusion::result_of::as_vector>();
     test_copy<C>();
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     test_move<C>();
@@ -54,5 +95,23 @@ test()
     test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<int, float>, int> >();
     test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<int, float> > >();
     test_all<FUSION_SEQUENCE<int, FUSION_SEQUENCE<int, float>, float> >();
+
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<>, FUSION_SEQUENCE<> > >();
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<int>, FUSION_SEQUENCE<> > >();
+    test_all<FUSION_SEQUENCE<FUSION_SEQUENCE<>, FUSION_SEQUENCE<int> > >();
+    test_all<
+        FUSION_SEQUENCE<FUSION_SEQUENCE<int>, FUSION_SEQUENCE<float> >
+    >();
+    test_all<
+        FUSION_SEQUENCE<FUSION_SEQUENCE<int, float>, FUSION_SEQUENCE<float> >
+    >();
+    test_all<
+        FUSION_SEQUENCE<FUSION_SEQUENCE<int>, FUSION_SEQUENCE<float, int> >
+    >();
+    test_all<
+        FUSION_SEQUENCE<
+            FUSION_SEQUENCE<int, float>, FUSION_SEQUENCE<float, int>
+        >
+    >();
 }
 


### PR DESCRIPTION
This patch fixes the C++11 copy/move from another fusion sequence type. The one problem with this patch is that `fusion::result_of::size` is not a constant _compile time_ operation for all fusion sequence types.

The most simple case that causes compilation error in C++03 and C++11:
```c++
#include <boost/fusion/tuple.hpp>
#include <boost/fusion/container/vector.hpp>
int main()
{
    typedef boost::fusion::vector<int> nested;
    const boost::fusion::tuple<nested> og(nested(1));
    boost::fusion::vector<nested> foo(og);
    return 0;
}
```
whereas this only fails in C++11 mode:
```c++
#include <boost/fusion/tuple.hpp>
#include <boost/fusion/container/vector.hpp>
int main()
{
    typedef boost::fusion::vector<int> nested;
    const boost::fusion::tuple<nested, nested> og(
        nested(1), nested(1)); 
    boost::fusion::vector<nested, nested> foo(og);
    return 0;
}
```
This patch adds tests for these cases, and fixes the C++11 version. Tests that currently fail are not compiled, and therefore all tests should still pass on develop. I ran all of the tests in C++03 and C++11 mode using Clang 3.5 on OSX - I can test on MSVC or Linux Gcc/Clang if necessary. The C++03 fixes and C++11 fixes for list and deque will have to be in future patches.