### PR TITLE
Fix failing "boost::fusion::make_vector(boost::phoenix::val(1));"

### DIFF
--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -75,10 +75,13 @@ namespace boost { namespace fusion
             Sequence
           , This
           , typename enable_if<traits::is_sequence<Sequence>>::type
-        >   : mpl::equal_to<
-                  fusion::result_of::size<Sequence>
-                , fusion::result_of::size<This>
-              >
+          >  : mpl::and_<
+                   mpl::equal_to<fusion::result_of::size<Sequence>, fusion::result_of::size<This> >
+                 , mpl::or_<
+                       mpl::not_<mpl::equal_to<fusion::result_of::size<This>, mpl::int_<1> >  >,
+                       mpl::not_<boost::is_convertible<Sequence, typename result_of::value_at_c<This, 0>::type> >
+                   >
+               >
         {
         };
 
@@ -326,4 +329,3 @@ namespace boost { namespace fusion
 
 #endif
 #endif
-


### PR DESCRIPTION
regression introduced in 79d8e9d11c07099bdf1db0724e8fb1ee92e98920

/cc @vtnerd 