### PR TITLE
Intel C++ compiler 17.0 workaround

### DIFF
--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -68,7 +68,7 @@ namespace boost { namespace fusion
 
         template <typename Sequence, typename This, int = result_of::size<This>::value>
         struct is_convertible_to_first
-            : boost::is_convertible<Sequence, typename result_of::value_at_c<This, 0>::type>
+            : boost::is_convertible<Sequence, typename fusion::result_of::value_at_c<This, 0>::type>
         {};
 
         template <typename Sequence, typename This>


### PR DESCRIPTION
This PR adds a workaround for Intel C++ compiler 17.0. Without the patch, I get the following errors:

```
boost/fusion/container/vector/vector.hpp(69): error: namespace "boost::fusion::vector_detail::result_of" has no member "value_at_c"
          : boost::is_convertible<Sequence, typename result_of::value_at_c<This, 0>::type>
                                                                ^
boost/fusion/container/vector/vector.hpp(69): error: expected a ">"
          : boost::is_convertible<Sequence, typename result_of::value_at_c<This, 0>::type>
                                                                          ^
boost/fusion/container/vector/vector.hpp(69): error: not a class or struct name
          : boost::is_convertible<Sequence, typename result_of::value_at_c<This, 0>::type>
            ^
```