### PR TITLE
Fix returing temporary variable warning on MSVC.

### DIFF
--- a/include/boost/fusion/container/deque/detail/keyed_element.hpp
+++ b/include/boost/fusion/container/deque/detail/keyed_element.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace fusion { namespace detail
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         keyed_element(keyed_element&& rhs)
-          : Rest(BOOST_FUSION_FWD_ELEM(Rest, rhs.forward_base()))
+          : Rest(rhs.forward_base())
           , value_(BOOST_FUSION_FWD_ELEM(Value, rhs.value_))
         {}
 #endif
@@ -90,7 +90,7 @@ namespace boost { namespace fusion { namespace detail
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         Rest&& forward_base() BOOST_NOEXCEPT
         {
-            return BOOST_FUSION_FWD_ELEM(Rest, *static_cast<Rest*>(this));
+            return std::move(*static_cast<Rest*>(this));
         }
 #endif
 
@@ -116,7 +116,7 @@ namespace boost { namespace fusion { namespace detail
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         keyed_element(Value&& value, Rest&& rest)
-            : Rest(BOOST_FUSION_FWD_ELEM(Rest, rest))
+            : Rest(std::move(rest))
             , value_(BOOST_FUSION_FWD_ELEM(Value, value))
         {}
 #endif
@@ -147,8 +147,8 @@ namespace boost { namespace fusion { namespace detail
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         keyed_element& operator=(keyed_element&& rhs)
         {
-            base::operator=(std::forward<keyed_element>(rhs));
-            value_ = BOOST_FUSION_FWD_ELEM(Value, rhs.value_);
+            base::operator=(rhs.forward_base());
+            value_ = std::move(rhs.value_);
             return *this;
         }
 #endif

--- a/test/sequence/conversion.hpp
+++ b/test/sequence/conversion.hpp
@@ -10,7 +10,8 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/fusion/adapted/boost_tuple.hpp>
 #include <boost/fusion/adapted/std_pair.hpp>
-#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE) \
+ && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
 # include <boost/fusion/adapted/std_tuple.hpp>
 #endif
 #include <boost/fusion/container/deque.hpp>
@@ -257,8 +258,9 @@ void test()
           , boost::tuple<convertible, int>(500, 400)
         )
     ));
-    
-#if !defined(BOOST_NO_CXX11_HDR_TUPLE)
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE) \
+ && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     BOOST_TEST((run< Scenario< FUSION_SEQUENCE<> > >(std::tuple<>())));
     BOOST_TEST((
         run<Scenario<FUSION_SEQUENCE<> > >(std::tuple<int>(100), std::tuple<>())


### PR DESCRIPTION
This PR will fix following warning on MSVC.

> boost/fusion/container/deque/detail/keyed_element.hpp(93) : warning C4172: returning address of local variable or temporary

Additionally, correct test condition that tried to use `std::tuple` without compiler support.

Tested
- GCC 6.2.1 20160916 - fedora rawhide
    - gnu++98 / gnu++11 / gnu++14
- Clang 3.8.0 - fedora rawhide
    - gnu++98 / gnu++11 / gnu++14
- MSVC
    - 2008sp1 / 2010sp1 / 2012u5 / 2013u5 / 2015u3
