### PR TITLE
Update workarounds for msvc 14.1

### DIFF
--- a/include/boost/fusion/container/deque/deque_fwd.hpp
+++ b/include/boost/fusion/container/deque/deque_fwd.hpp
@@ -23,8 +23,7 @@
 # endif
 #endif
 
-// MSVC variadics at this point in time is not ready yet (ICE!)
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1900))
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
 # if defined(BOOST_FUSION_HAS_VARIADIC_DEQUE)
 #   undef BOOST_FUSION_HAS_VARIADIC_DEQUE
 # endif

--- a/include/boost/fusion/container/map/map_fwd.hpp
+++ b/include/boost/fusion/container/map/map_fwd.hpp
@@ -23,8 +23,7 @@
 # endif
 #endif
 
-// MSVC variadics at this point in time is not ready yet (ICE!)
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1900))
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
 # if defined(BOOST_FUSION_HAS_VARIADIC_MAP)
 #   undef BOOST_FUSION_HAS_VARIADIC_MAP
 # endif

--- a/include/boost/fusion/container/vector/detail/config.hpp
+++ b/include/boost/fusion/container/vector/detail/config.hpp
@@ -27,8 +27,7 @@
 # endif
 #endif
 
-// Sometimes, MSVC 12 shows compile error with std::size_t of template parameter.
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1800))
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
 # if defined(BOOST_FUSION_HAS_VARIADIC_VECTOR)
 #   undef BOOST_FUSION_HAS_VARIADIC_VECTOR
 # endif


### PR DESCRIPTION
close [Trac #12986](https://svn.boost.org/trac/boost/ticket/12986)

Variadics now works fine with msvc 14.1.

Tested under:
- Visual Studio 2015 update 3 (14.0)
- Visual Studio 2017 (14.1)