### PR TITLE
isspace(c) is not a macro in Dinkum clib for VxWorks

### DIFF
--- a/include/boost/fusion/sequence/io/detail/manip.hpp
+++ b/include/boost/fusion/sequence/io/detail/manip.hpp
@@ -131,6 +131,7 @@ namespace boost { namespace fusion
             void
             check_delim(Char c) const
             {
+                using namespace std;
                 if (!isspace(c))
                 {
                     if (stream.get() != c)


### PR DESCRIPTION
Must be in std namespace