### PR TITLE
Change base of tuple

### DIFF
--- a/include/boost/fusion/container/vector/detail/value_at_impl.hpp
+++ b/include/boost/fusion/container/vector/detail/value_at_impl.hpp
@@ -23,7 +23,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <boost/fusion/container/vector/vector_fwd.hpp>
 #include <boost/type_traits/declval.hpp>
-#include <boost/type_traits/remove_cv.hpp>
 
 namespace boost { namespace fusion
 {
@@ -31,8 +30,12 @@ namespace boost { namespace fusion
 
     namespace vector_detail
     {
-        template <typename I, typename ...T>
-        struct vector_data;
+        template <std::size_t I, typename T>
+        struct store;
+
+        template <std::size_t N, typename U>
+        static inline BOOST_FUSION_GPU_ENABLED
+        U value_at_impl(store<N, U> const volatile*);
     }
 
     namespace extension
@@ -46,8 +49,9 @@ namespace boost { namespace fusion
             template <typename Sequence, typename N>
             struct apply
             {
-                typedef typename boost::remove_cv<Sequence>::type seq;
-                typedef typename mpl::identity<decltype(seq::template value_at_impl<N::value>(boost::declval<seq*>()))>::type::type type;
+                typedef
+                    decltype(vector_detail::value_at_impl<N::value>(boost::declval<Sequence*>()))
+                type;
             };
         };
     }

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -133,27 +133,27 @@ namespace boost { namespace fusion
 
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             store(store const& rhs)
-                : elem(rhs.get())
+                : elem(rhs.elem)
             {}
 
             BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             store&
             operator=(store const& rhs)
             {
-                elem = rhs.get();
+                elem = rhs.elem;
                 return *this;
             }
 
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             store(store&& rhs)
-                : elem(static_cast<T&&>(rhs.get()))
+                : elem(static_cast<T&&>(rhs.elem))
             {}
 
             BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             store&
             operator=(store&& rhs)
             {
-                elem = static_cast<T&&>(rhs.get());
+                elem = static_cast<T&&>(rhs.elem);
                 return *this;
             }
 
@@ -167,11 +167,6 @@ namespace boost { namespace fusion
             store(U&& rhs)
                 : elem(std::forward<U>(rhs))
             {}
-
-            BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            T      & get()       { return elem; }
-            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            T const& get() const { return elem; }
 
             T elem;
         };
@@ -238,16 +233,16 @@ namespace boost { namespace fusion
 
             template <std::size_t N, typename U>
             static BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            auto at_detail(store<N, U>* this_) -> decltype(this_->get())
+            U& at_detail(store<N, U>* this_)
             {
-                return this_->get();
+                return this_->elem;
             }
 
             template <std::size_t N, typename U>
             static BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            auto at_detail(store<N, U> const* this_) -> decltype(this_->get())
+            U const& at_detail(store<N, U> const* this_)
             {
-                return this_->get();
+                return this_->elem;
             }
 
             template <typename J>

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -306,13 +306,11 @@ namespace boost { namespace fusion
 
         template <
             typename Sequence
-          , typename Sequence_ = typename remove_reference<Sequence>::type
-          , typename = typename boost::enable_if_c<(
-                !is_base_of<vector, Sequence_>::value &&
+          , typename = typename boost::enable_if_c<
                 vector_detail::is_longer_sequence<
-                    Sequence_, sizeof...(T)
+                    typename remove_reference<Sequence>::type, sizeof...(T)
                 >::value
-            )>::type
+            >::type
         >
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         vector(Sequence&& seq)

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -258,10 +258,6 @@ namespace boost { namespace fusion
             {
                 return at_detail<J::value>(this);
             }
-
-            template <std::size_t N, typename U>
-            static BOOST_FUSION_GPU_ENABLED
-            mpl::identity<U> value_at_impl(store<N, U>*);
         };
     } // namespace boost::fusion::vector_detail
 

--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -192,8 +192,7 @@ namespace boost { namespace fusion
             typedef vector<T...>                type_sequence;
 
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            vector_data()
-            {}
+            BOOST_DEFAULTED_FUNCTION(vector_data(), {})
 
             template <
                 typename Sequence
@@ -284,8 +283,7 @@ namespace boost { namespace fusion
         > base;
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        vector()
-        {}
+        BOOST_DEFAULTED_FUNCTION(vector(), {})
 
         template <
             typename... U

--- a/include/boost/fusion/tuple/tuple.hpp
+++ b/include/boost/fusion/tuple/tuple.hpp
@@ -34,13 +34,19 @@
 namespace boost { namespace fusion
 {
     template <typename ...T>
-    struct tuple : vector<T...>
+    struct tuple
+        : vector_detail::vector_data<
+              typename detail::make_index_sequence<sizeof...(T)>::type
+            , T...
+          >
     {
-        typedef vector<T...> base_type;
+        typedef vector_detail::vector_data<
+            typename detail::make_index_sequence<sizeof...(T)>::type
+          , T...
+        > base;
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        tuple()
-            : base_type() {}
+        BOOST_DEFAULTED_FUNCTION(tuple(), {})
 
         template <
             typename ...U
@@ -50,7 +56,7 @@ namespace boost { namespace fusion
         >
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         tuple(tuple<U...> const& other)
-            : base_type(other) {}
+            : base(vector_detail::each_elem(), other) {}
 
         template <
             typename ...U
@@ -60,7 +66,7 @@ namespace boost { namespace fusion
         >
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         tuple(tuple<U...>&& other)
-            : base_type(std::move(other)) {}
+            : base(vector_detail::each_elem(), std::move(other)) {}
 
         template <
             typename ...U
@@ -72,23 +78,23 @@ namespace boost { namespace fusion
         /*BOOST_CONSTEXPR*/ BOOST_FUSION_GPU_ENABLED
         explicit
         tuple(U&&... args)
-            : base_type(std::forward<U>(args)...) {}
+            : base(vector_detail::each_elem(), std::forward<U>(args)...) {}
 
         template<typename U1, typename U2>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         tuple(std::pair<U1, U2> const& other)
-            : base_type(other.first, other.second) {}
+            : base(vector_detail::each_elem(), other.first, other.second) {}
 
         template<typename U1, typename U2>
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         tuple(std::pair<U1, U2>&& other)
-            : base_type(std::move(other.first), std::move(other.second)) {}
+            : base(vector_detail::each_elem(), std::move(other.first), std::move(other.second)) {}
 
         template<typename U>
         BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         tuple& operator=(U&& rhs)
         {
-            base_type::operator=(std::forward<U>(rhs));
+            base::assign_sequence(std::forward<U>(rhs));
             return *this;
         }
     };


### PR DESCRIPTION
As discussed on [1], change base class of `fusion::tuple` to `vector_detail::vector_data` to improve compile time performance and conversion stability.

Tested:
- GCC 7.2.1 20170829
- Clang 4.0.1

[1] [[Spirit-general] [fusion] Proposal for deprecating fusion.tuple.](https://sourceforge.net/p/spirit/mailman/spirit-general/thread/ed8d507e-f79d-6710-644e-8b11417f7a2c@flast.jp/#msg36056640)