### PR TITLE
Update CI status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,7 @@ branches:
     - master
     - develop
 
-env:
-  matrix:
-    - BOGUS_JOB=true
-
 matrix:
-
-  exclude:
-    - env: BOGUS_JOB=true
-
   include:
     - os: linux
       compiler: g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,15 @@ branches:
     - master
     - develop
 
+env:
+  matrix:
+    - BOGUS_JOB=true
+
 matrix:
+
+  exclude:
+    - env: BOGUS_JOB=true
+
   include:
     - os: linux
       compiler: g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -547,4 +547,4 @@ install:
 script:
   - |-
     echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
-  - ./b2 libs/fusion/test toolset=$TOOLSET
+  - ./b2 libs/fusion/test toolset=$TOOLSET define=RUNNING_ON_TRAVIS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -548,7 +548,3 @@ script:
   - |-
     echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
   - ./b2 libs/fusion/test toolset=$TOOLSET
-
-notifications:
-  email:
-    on_success: always

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ install:
 build: off
 
 test_script:
-  - b2 libs/fusion/test toolset=%TOOLSET%
+  - b2 libs/fusion/test toolset=%TOOLSET% define=RUNNING_ON_APPVEYOR=1

--- a/meta/explicit-failures-markup.xml
+++ b/meta/explicit-failures-markup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<explicit-failures-markup>
+    <!-- fusion -->
+    <library name="fusion">
+        <mark-expected-failures>
+            <toolset name="msvc-10.0"/>
+            <toolset name="msvc-11.0"/>
+            <toolset name="msvc-12.0"/>
+            <test name="define_struct_inline_move"/>
+            <test name="define_tpl_struct_inline_move"/>
+            <note author="Kohei Takahashi">
+                The compiler doesn't generate defaulted move ctor/assgin thus
+                perform copy construction/assginment. The `inline` versions
+                don't provide move ctor/assign to preserve standard layout
+                constraint. Since that is not documented behaviour, it might
+                be changed in future release.
+            </note>
+        </mark-expected-failures>
+    </library>
+</explicit-failures-markup>

--- a/test/sequence/define_struct_inline_move.cpp
+++ b/test/sequence/define_struct_inline_move.cpp
@@ -51,6 +51,8 @@ int main()
         BOOST_TEST(y.w.value == 42);
     }
 
+    // Older MSVCs don't generate move ctor by default.
+#if !(defined(RUNNING_ON_APPVEYOR) && BOOST_WORKAROUND(BOOST_MSVC, < 1900))
     {
         ns::value x;
         ns::value y(std::move(x)); // move
@@ -68,6 +70,7 @@ int main()
         BOOST_TEST(x.w.value == 0);
         BOOST_TEST(y.w.value == 0);
     }
+#endif // !(appveyor && msvc < 14.0)
 
     return boost::report_errors();
 }

--- a/test/sequence/define_tpl_struct_inline_move.cpp
+++ b/test/sequence/define_tpl_struct_inline_move.cpp
@@ -51,6 +51,8 @@ int main()
         BOOST_TEST(y.w.value == 42);
     }
 
+    // Older MSVCs don't generate move ctor by default.
+#if !(defined(RUNNING_ON_APPVEYOR) && BOOST_WORKAROUND(BOOST_MSVC, < 1900))
     {
         ns::value<wrapper> x;
         ns::value<wrapper> y(std::move(x)); // move
@@ -68,6 +70,7 @@ int main()
         BOOST_TEST(x.w.value == 0);
         BOOST_TEST(y.w.value == 0);
     }
+#endif // !(appveyor && msvc < 14.0)
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Skipping `define_struct_inline_move` and `define_tpl_struct_inline_move` on AppVeyor due to msvc's bug. 