### PR TITLE
Make explicit-failures-markup.xml valid

### DIFF
--- a/meta/explicit-failures-markup.xml
+++ b/meta/explicit-failures-markup.xml
@@ -3,11 +3,11 @@
     <!-- fusion -->
     <library name="fusion">
         <mark-expected-failures>
+            <test name="define_struct_inline_move"/>
+            <test name="define_tpl_struct_inline_move"/>
             <toolset name="msvc-10.0"/>
             <toolset name="msvc-11.0"/>
             <toolset name="msvc-12.0"/>
-            <test name="define_struct_inline_move"/>
-            <test name="define_tpl_struct_inline_move"/>
             <note author="Kohei Takahashi">
                 The compiler doesn't generate defaulted move ctor/assgin thus
                 perform copy construction/assginment. The `inline` versions


### PR DESCRIPTION
The xml needs to be valid according to:

https://github.com/boostorg/boost/blob/develop/status/explicit-failures.xsd

It requires that the elements are in a certain order. I suspect that the
scripts don't actually require that, but I don't know for sure.