### PR TITLE
vector: Fix for compilers not compatible with CWG defect 945

### DIFF
--- a/include/boost/fusion/container/vector/vector.hpp
+++ b/include/boost/fusion/container/vector/vector.hpp
@@ -247,14 +247,14 @@ namespace boost { namespace fusion
 
             template <typename J>
             BOOST_CXX14_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            auto at_impl(J) -> decltype(at_detail<J::value>(this))
+            auto at_impl(J) -> decltype(at_detail<J::value>(&std::declval<vector_data&>()))
             {
                 return at_detail<J::value>(this);
             }
 
             template <typename J>
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            auto at_impl(J) const -> decltype(at_detail<J::value>(this))
+            auto at_impl(J) const -> decltype(at_detail<J::value>(&std::declval<vector_data const&>()))
             {
                 return at_detail<J::value>(this);
             }


### PR DESCRIPTION
Closes #160 (I believe).
Reject the PR if you are not going to add support for compilers that do not support [CWG defect 945](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#945) (c++11 in clang 3.0, gcc 4.6?). Also, I am not sure this is enough and there are no other problems with them.