### PR TITLE
Add limits precheck

### DIFF
--- a/include/boost/fusion/container/deque/detail/cpp03/as_deque.hpp
+++ b/include/boost/fusion/container/deque/detail/cpp03/as_deque.hpp
@@ -26,7 +26,13 @@ namespace boost { namespace fusion { namespace detail
 BOOST_FUSION_BARRIER_BEGIN
 
     template <int size>
-    struct as_deque;
+    struct as_deque
+    {
+        BOOST_STATIC_ASSERT_MSG(
+            size <= FUSION_MAX_DEQUE_SIZE
+          , "FUSION_MAX_DEQUE_SIZE limit is too low"
+        );
+    };
 
     template <>
     struct as_deque<0>

--- a/include/boost/fusion/container/map/detail/cpp03/as_map.hpp
+++ b/include/boost/fusion/container/map/detail/cpp03/as_map.hpp
@@ -25,7 +25,13 @@ namespace boost { namespace fusion { namespace detail
 BOOST_FUSION_BARRIER_BEGIN
 
     template <int size, bool is_assoc>
-    struct as_map;
+    struct as_map
+    {
+        BOOST_STATIC_ASSERT_MSG(
+            size <= FUSION_MAX_MAP_SIZE
+          , "FUSION_MAX_MAP_SIZE limit is too low"
+        );
+    };
 
     template <bool is_assoc>
     struct as_map<0, is_assoc>

--- a/include/boost/fusion/container/set/detail/cpp03/as_set.hpp
+++ b/include/boost/fusion/container/set/detail/cpp03/as_set.hpp
@@ -25,7 +25,13 @@ namespace boost { namespace fusion { namespace detail
 BOOST_FUSION_BARRIER_BEGIN
 
     template <int size>
-    struct as_set;
+    struct as_set
+    {
+        BOOST_STATIC_ASSERT_MSG(
+            size <= FUSION_MAX_SET_SIZE
+          , "FUSION_MAX_SET_SIZE limit is too low"
+        );
+    };
 
     template <>
     struct as_set<0>

--- a/include/boost/fusion/container/vector/detail/cpp03/as_vector.hpp
+++ b/include/boost/fusion/container/vector/detail/cpp03/as_vector.hpp
@@ -25,7 +25,13 @@ namespace boost { namespace fusion { namespace detail
 BOOST_FUSION_BARRIER_BEGIN
 
     template <int size>
-    struct as_vector;
+    struct as_vector
+    {
+        BOOST_STATIC_ASSERT_MSG(
+            size <= FUSION_MAX_VECTOR_SIZE
+          , "FUSION_MAX_VECTOR_SIZE limit is too low"
+        );
+    };
 
     template <>
     struct as_vector<0>


### PR DESCRIPTION
It makes errors way more clearer when fusion container is build from fusion sequence (e.g. fusion list, mpl sequence, and etc).