### PR TITLE
Allow incomplete types in fusion::tag_of and fusion::is_native_fusion_sequence

### DIFF
--- a/include/boost/fusion/support/detail/is_mpl_sequence.hpp
+++ b/include/boost/fusion/support/detail/is_mpl_sequence.hpp
@@ -13,6 +13,7 @@
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
+#include <boost/type_traits/is_complete.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
 namespace boost { namespace fusion { namespace detail
@@ -20,7 +21,7 @@ namespace boost { namespace fusion { namespace detail
     template <typename T>
     struct is_mpl_sequence
         : mpl::and_<
-            mpl::not_<is_convertible<T, from_sequence_convertible_type> >
+            mpl::not_<mpl::and_<is_complete<T>, is_convertible<T, from_sequence_convertible_type> > >
           , mpl::is_sequence<T> >
     {};
 }}}

--- a/include/boost/fusion/support/is_sequence.hpp
+++ b/include/boost/fusion/support/is_sequence.hpp
@@ -10,9 +10,11 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/support/sequence_base.hpp>
 #include <boost/fusion/support/tag_of.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/or.hpp>
-#include <boost/mpl/bool.hpp>
+#include <boost/type_traits/is_complete.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_same.hpp>
 
@@ -69,7 +71,10 @@ namespace boost { namespace fusion
 
         template <typename Sequence, typename Enable = void>
         struct is_native_fusion_sequence
-          : is_convertible<Sequence, fusion::detail::from_sequence_convertible_type>
+          : mpl::and_<
+            is_complete<Sequence>,
+            is_convertible<Sequence, fusion::detail::from_sequence_convertible_type>
+          >
         {};
     }
 }}

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -254,6 +254,7 @@ project
     [ run functional/invoke_procedure.cpp ]
     [ run sequence/swap.cpp ]
 
+    [ compile support/is_sequence.cpp ]
     [ compile support/pair_deque.cpp ]
     [ compile support/pair_list.cpp ]
     [ compile support/pair_map.cpp ]
@@ -264,6 +265,7 @@ project
         : [ requires cxx11_variadic_templates ] ]
     [ compile support/and.cpp
         : [ requires cxx11_variadic_templates ] ]
+    [ compile support/tag_of.cpp ]
 
 #   [ compile-fail xxx.cpp  ]
 

--- a/test/support/is_sequence.cpp
+++ b/test/support/is_sequence.cpp
@@ -1,0 +1,17 @@
+/*=============================================================================
+    Copyright (c) 2018 Louis Dionne
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/support/is_sequence.hpp>
+#include <boost/static_assert.hpp>
+
+
+// Make sure fusion::is_sequence and fusion::is_native_fusion_sequence can be
+// used with an incomplete type.
+struct incomplete;
+BOOST_STATIC_ASSERT(!boost::fusion::traits::is_sequence<incomplete>::value);
+BOOST_STATIC_ASSERT(!boost::fusion::traits::is_native_fusion_sequence<incomplete>::value);
+
+int main() { }

--- a/test/support/tag_of.cpp
+++ b/test/support/tag_of.cpp
@@ -1,0 +1,17 @@
+/*=============================================================================
+    Copyright (c) 2018 Louis Dionne
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/support/tag_of.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+
+// Make sure tag_of can be used with an incomplete type.
+struct incomplete;
+typedef boost::fusion::traits::tag_of<incomplete>::type Tag;
+BOOST_STATIC_ASSERT((boost::is_same<Tag, boost::fusion::non_fusion_tag>::value));
+
+int main() { }


### PR DESCRIPTION
Fixes #170 

Please merge this before the 1.67.0 release, as this is a regression.