### PR TITLE
Fixed detail::and test

### DIFF
--- a/test/support/and.cpp
+++ b/test/support/and.cpp
@@ -11,24 +11,18 @@
 #   error "does not meet requirements"
 #endif
 
-#include <boost/detail/lightweight_test.hpp>
 #include <boost/fusion/support/detail/and.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/type_traits/integral_constant.hpp>
+#include <boost/mpl/assert.hpp>
 
-int main() {
-    using namespace boost;
-    using namespace boost::fusion::detail;
+using namespace boost;
+using namespace boost::fusion::detail;
 
-    BOOST_TEST((and_<>::value));
-    BOOST_TEST(!(and_<false_type>::value));
-    BOOST_TEST((and_<true_type>::value));
-    BOOST_TEST(!(and_<true_type, false_type>::value));
-    BOOST_TEST((and_<true_type, true_type>::value));
-    BOOST_TEST(!(and_<true_type, true_type, false_type>::value));
-    BOOST_TEST((and_<true_type, true_type, true_type>::value));
-    BOOST_TEST((and_<true_type, mpl::true_>::value));
-
-    return boost::report_errors();
-}
-
+BOOST_MPL_ASSERT((and_<>));
+BOOST_MPL_ASSERT_NOT((and_<false_type>));
+BOOST_MPL_ASSERT((and_<true_type>));
+BOOST_MPL_ASSERT_NOT((and_<true_type, false_type>));
+BOOST_MPL_ASSERT((and_<true_type, true_type>));
+BOOST_MPL_ASSERT_NOT((and_<true_type, true_type, false_type>));
+BOOST_MPL_ASSERT((and_<true_type, true_type, true_type>));
+BOOST_MPL_ASSERT((and_<true_type, mpl::true_>));


### PR DESCRIPTION
The test always passed because tested compilation only not invoked.