### PR TITLE
adapt/adt: Don't add/remove const on return type of attributes

### DIFF
--- a/include/boost/fusion/adapted/adt/detail/adapt_base.hpp
+++ b/include/boost/fusion/adapted/adt/detail/adapt_base.hpp
@@ -21,7 +21,6 @@
 #include <boost/preprocessor/tuple/elem.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_const.hpp>
-#include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
@@ -84,20 +83,8 @@
     typedef                                                                     \
         BOOST_PP_EXPR_IF(BOOST_FUSION_ADAPT_IS_TPL(TEMPLATE_PARAMS_SEQ),        \
                          typename)                                              \
-        boost::remove_const<                                                    \
-          BOOST_PP_EXPR_IF(BOOST_FUSION_ADAPT_IS_TPL(TEMPLATE_PARAMS_SEQ),      \
-                           typename) \
-          deduced_attr_type::type                                               \
-        >::type type;                                                           \
-                                                                                \
-    typedef                                                                     \
-        BOOST_PP_EXPR_IF(BOOST_FUSION_ADAPT_IS_TPL(TEMPLATE_PARAMS_SEQ),        \
-                         typename)   \
-        boost::add_const<                                                       \
-          BOOST_PP_EXPR_IF(BOOST_FUSION_ADAPT_IS_TPL(TEMPLATE_PARAMS_SEQ),      \
-                           typename) \
-          deduced_attr_type::type                                               \
-    >::type const_type;
+        deduced_attr_type::type type;                                           \
+    typedef type const_type;
 
 #define BOOST_FUSION_ADT_ATTRIBUTE_GIVENTYPE(                                   \
     NAME_SEQ, ATTRIBUTE, ATTRIBUTE_TUPLE_SIZE, PREFIX, TEMPLATE_PARAMS_SEQ)     \

--- a/test/sequence/adapt_adt.cpp
+++ b/test/sequence/adapt_adt.cpp
@@ -300,7 +300,7 @@ main()
         BOOST_MPL_ASSERT((
             boost::is_same<
                 boost::fusion::result_of::back<ns::point const>::type::type,
-                const int
+                int
             >));
     }
 


### PR DESCRIPTION
Boost.TypeOf always deduces the type as un-cv-qualified value type, thus const-ized
value type is redundant and inhibiting compiler optimization.