### PR TITLE
Define traits::is_view for non fusion types

### DIFF
--- a/include/boost/fusion/support/is_view.hpp
+++ b/include/boost/fusion/support/is_view.hpp
@@ -14,6 +14,7 @@
 namespace boost { namespace fusion
 {
     // Special tags:
+    struct non_fusion_tag;
     struct sequence_facade_tag;
     struct boost_tuple_tag; // boost::tuples::tuple tag
     struct boost_array_tag; // boost::array tag
@@ -30,6 +31,13 @@ namespace boost { namespace fusion
             {
                 typedef typename T::is_view type;
             };
+        };
+
+        template <>
+        struct is_view_impl<non_fusion_tag>
+        {
+            template <typename T>
+            struct apply : mpl::false_ {};
         };
 
         template <>

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -257,6 +257,7 @@ project
     [ run sequence/swap.cpp ]
 
     [ compile support/is_sequence.cpp ]
+    [ compile support/is_view.cpp ]
     [ compile support/pair_deque.cpp ]
     [ compile support/pair_list.cpp ]
     [ compile support/pair_map.cpp ]

--- a/test/sequence/adapt_adt.cpp
+++ b/test/sequence/adapt_adt.cpp
@@ -165,6 +165,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<ns::point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<ns::point>::value);
         ns::point p(123, 456, 789);
 
         std::cout << at_c<0>(p) << std::endl;
@@ -237,6 +238,7 @@ main()
 #if !BOOST_WORKAROUND(__GNUC__,<4)
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<ns::point_with_private_members>));
+        BOOST_STATIC_ASSERT(!traits::is_view<ns::point_with_private_members>::value);
         ns::point_with_private_members p(123, 456, 789);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_adt_empty.cpp
+++ b/test/sequence/adapt_adt_empty.cpp
@@ -42,6 +42,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_adt>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_adt>::value);
         empty_adt e;
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_adt_named.cpp
+++ b/test/sequence/adapt_adt_named.cpp
@@ -93,6 +93,7 @@ main()
 
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::point>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::point>::value);
         ns::point basep(123, 456, 789);
         adapted::point p(basep);
 

--- a/test/sequence/adapt_adt_named_empty.cpp
+++ b/test/sequence/adapt_adt_named_empty.cpp
@@ -43,6 +43,7 @@ main()
     empty_adt empty;
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::empty_adt>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::empty_adt>::value);
         adapted::empty_adt e(empty);
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_assoc_adt.cpp
+++ b/test/sequence/adapt_assoc_adt.cpp
@@ -84,6 +84,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<ns::point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<ns::point>::value);
         ns::point p(123, 456, 789);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_assoc_adt_empty.cpp
+++ b/test/sequence/adapt_assoc_adt_empty.cpp
@@ -42,6 +42,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_adt>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_adt>::value);
         empty_adt e;
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_assoc_adt_named.cpp
+++ b/test/sequence/adapt_assoc_adt_named.cpp
@@ -80,6 +80,7 @@ main()
 
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::point>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::point>::value);
         ns::point basep(123, 456);
         adapted::point p(basep);
 

--- a/test/sequence/adapt_assoc_adt_named_empty.cpp
+++ b/test/sequence/adapt_assoc_adt_named_empty.cpp
@@ -43,6 +43,7 @@ main()
     empty_adt empty;
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::empty_adt>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::empty_adt>::value);
         adapted::empty_adt e(empty);
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_assoc_struct.cpp
+++ b/test/sequence/adapt_assoc_struct.cpp
@@ -86,6 +86,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<ns::point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<ns::point>::value);
         ns::point p = {123, 456, 789};
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_assoc_struct_empty.cpp
+++ b/test/sequence/adapt_assoc_struct_empty.cpp
@@ -42,6 +42,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_struct>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_struct>::value);
         empty_struct e;
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_assoc_struct_named.cpp
+++ b/test/sequence/adapt_assoc_struct_named.cpp
@@ -66,6 +66,7 @@ main()
 
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::point>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::point>::value);
         ns::point basep = {123, 456};
         adapted::point p(basep);
 

--- a/test/sequence/adapt_assoc_struct_named_empty.cpp
+++ b/test/sequence/adapt_assoc_struct_named_empty.cpp
@@ -43,6 +43,7 @@ main()
     empty_struct empty;
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::empty_struct>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::empty_struct>::value);
         adapted::empty_struct e(empty);
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_assoc_tpl_adt.cpp
+++ b/test/sequence/adapt_assoc_tpl_adt.cpp
@@ -98,6 +98,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p(123, 456, 789);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_assoc_tpl_struct.cpp
+++ b/test/sequence/adapt_assoc_tpl_struct.cpp
@@ -96,6 +96,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p = {123, 456, 789.43f};
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_struct.cpp
+++ b/test/sequence/adapt_struct.cpp
@@ -170,6 +170,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p = {123, 456, 789};
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_struct_empty.cpp
+++ b/test/sequence/adapt_struct_empty.cpp
@@ -42,6 +42,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_struct>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_struct>::value);
         empty_struct e;
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_struct_named.cpp
+++ b/test/sequence/adapt_struct_named.cpp
@@ -87,6 +87,7 @@ main()
 
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::point>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::point>::value);
         ns::point basep = {123, 456, 789};
         adapted::point p(basep);
 

--- a/test/sequence/adapt_struct_named_empty.cpp
+++ b/test/sequence/adapt_struct_named_empty.cpp
@@ -43,6 +43,7 @@ main()
     empty_struct empty;
     {
         BOOST_MPL_ASSERT((traits::is_view<adapted::empty_struct>));
+        BOOST_STATIC_ASSERT(traits::is_view<adapted::empty_struct>::value);
         adapted::empty_struct e(empty);
 
         std::cout << e << std::endl;

--- a/test/sequence/adapt_tpl_adt.cpp
+++ b/test/sequence/adapt_tpl_adt.cpp
@@ -107,6 +107,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p(123, 456, 789);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/adapt_tpl_struct.cpp
+++ b/test/sequence/adapt_tpl_struct.cpp
@@ -96,6 +96,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p = {123, 456, 789};
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/array.cpp
+++ b/test/sequence/array.cpp
@@ -22,6 +22,8 @@ int main()
 
     BOOST_MPL_ASSERT((traits::is_sequence<array_type>));
     BOOST_MPL_ASSERT_NOT((traits::is_view<array_type>));
+    BOOST_STATIC_ASSERT(traits::is_sequence<array_type>::value);
+    BOOST_STATIC_ASSERT(!traits::is_view<array_type>::value);
 
     array_type arr = {1,2,3};
 

--- a/test/sequence/boost_array.cpp
+++ b/test/sequence/boost_array.cpp
@@ -26,6 +26,8 @@ int main()
 
     BOOST_MPL_ASSERT((traits::is_sequence<array_type>));
     BOOST_MPL_ASSERT_NOT((traits::is_view<array_type>));
+    BOOST_STATIC_ASSERT(traits::is_sequence<array_type>::value);
+    BOOST_STATIC_ASSERT(!traits::is_view<array_type>::value);
 
     array_type arr = {{1,2,3}};
 

--- a/test/sequence/boost_tuple.cpp
+++ b/test/sequence/boost_tuple.cpp
@@ -46,6 +46,7 @@ main()
     {
         typedef boost::tuple<int, std::string> tuple_type;
         BOOST_MPL_ASSERT_NOT((traits::is_view<tuple_type>));
+        BOOST_STATIC_ASSERT(!traits::is_view<tuple_type>::value);
         tuple_type t(123, "Hola!!!");
 
         std::cout << at_c<0>(t) << std::endl;

--- a/test/sequence/define_assoc_struct.cpp
+++ b/test/sequence/define_assoc_struct.cpp
@@ -42,6 +42,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<ns::point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<ns::point>::value);
         ns::point p(123, 456);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/define_assoc_struct_empty.cpp
+++ b/test/sequence/define_assoc_struct_empty.cpp
@@ -30,6 +30,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_struct>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_struct>::value);
         empty_struct e;
 
         std::cout << e << std::endl;

--- a/test/sequence/define_assoc_tpl_struct.cpp
+++ b/test/sequence/define_assoc_tpl_struct.cpp
@@ -46,6 +46,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p(123, 456);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/define_assoc_tpl_struct_empty.cpp
+++ b/test/sequence/define_assoc_tpl_struct_empty.cpp
@@ -30,6 +30,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_struct<void> >));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_struct<void> >::value);
         empty_struct<void> e;
 
         std::cout << e << std::endl;

--- a/test/sequence/define_struct.cpp
+++ b/test/sequence/define_struct.cpp
@@ -54,6 +54,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<ns::point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<ns::point>::value);
         ns::point p(123, 456);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/define_struct_empty.cpp
+++ b/test/sequence/define_struct_empty.cpp
@@ -30,6 +30,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_struct>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_struct>::value);
         empty_struct e;
 
         std::cout << e << std::endl;

--- a/test/sequence/define_struct_inline.cpp
+++ b/test/sequence/define_struct_inline.cpp
@@ -66,6 +66,7 @@ void run_test()
     
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<Point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<Point>::value);
         Point p(123, 456);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/define_struct_inline_empty.cpp
+++ b/test/sequence/define_struct_inline_empty.cpp
@@ -30,6 +30,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<empty_struct>));
+        BOOST_STATIC_ASSERT(!traits::is_view<empty_struct>::value);
         empty_struct e;
 
         std::cout << e << std::endl;

--- a/test/sequence/define_tpl_struct.cpp
+++ b/test/sequence/define_tpl_struct.cpp
@@ -42,6 +42,7 @@ main()
 
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<point>::value);
         point p(123, 456);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/define_tpl_struct_inline.cpp
+++ b/test/sequence/define_tpl_struct_inline.cpp
@@ -61,6 +61,7 @@ void run_test()
     
     {
         BOOST_MPL_ASSERT_NOT((traits::is_view<Point>));
+        BOOST_STATIC_ASSERT(!traits::is_view<Point>::value);
         Point p(123, 456);
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/sequence/set.cpp
+++ b/test/sequence/set.cpp
@@ -89,6 +89,9 @@ main()
         BOOST_MPL_ASSERT((traits::is_sequence<t1>));
         BOOST_MPL_ASSERT((traits::is_sequence<t2>));
         BOOST_MPL_ASSERT((traits::is_sequence<t3>));
+        BOOST_STATIC_ASSERT(traits::is_sequence<t1>::value);
+        BOOST_STATIC_ASSERT(traits::is_sequence<t2>::value);
+        BOOST_STATIC_ASSERT(traits::is_sequence<t3>::value);
     }
 
     {   // testing mpl::is_sequence

--- a/test/sequence/std_array.cpp
+++ b/test/sequence/std_array.cpp
@@ -33,6 +33,8 @@ int main()
 
     BOOST_MPL_ASSERT((traits::is_sequence<array_type>));
     BOOST_MPL_ASSERT_NOT((traits::is_view<array_type>));
+    BOOST_STATIC_ASSERT(traits::is_sequence<array_type>::value);
+    BOOST_STATIC_ASSERT(!traits::is_view<array_type>::value);
 
     array_type arr = {{1,2,3}};
 

--- a/test/sequence/std_pair.cpp
+++ b/test/sequence/std_pair.cpp
@@ -44,6 +44,7 @@ main()
     {
         typedef std::pair<int, std::string> pair_type;
         BOOST_MPL_ASSERT_NOT((traits::is_view<pair_type>));
+        BOOST_STATIC_ASSERT(!traits::is_view<pair_type>::value);
         pair_type p(123, "Hola!!!");
 
         std::cout << at_c<0>(p) << std::endl;

--- a/test/support/is_view.cpp
+++ b/test/support/is_view.cpp
@@ -1,0 +1,15 @@
+/*=============================================================================
+    Copyright (c) 2018 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/support/is_view.hpp>
+#include <boost/static_assert.hpp>
+
+
+// Make sure fusion::is_view can be used with non fusion types.
+struct incomplete;
+BOOST_STATIC_ASSERT(!boost::fusion::traits::is_view<incomplete>::value);
+
+int main() { }


### PR DESCRIPTION
Fixes #189.

Also adds `traits::is_sequence` tests for the same usage.