### PR TITLE
Update decltype(expr)::type WA for Clang 3.0

### DIFF
--- a/include/boost/fusion/support/config.hpp
+++ b/include/boost/fusion/support/config.hpp
@@ -99,7 +99,9 @@ namespace std
 
 // Workaround for compiler which doesn't compile decltype(expr)::type.
 // It expects decltype(expr) deduced as mpl::identity<T>.
-#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1913)) || BOOST_WORKAROUND(BOOST_GCC, < 40700)
+#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1913)) || \
+    BOOST_WORKAROUND(BOOST_GCC, < 40700) || \
+    defined(BOOST_CLANG) && (__clang_major__ == 3 && __clang_minor__ == 0)
 #   include <boost/mpl/identity.hpp>
 #   define BOOST_FUSION_IDENTIFIED_TYPE(parenthesized_expr) \
         boost::mpl::identity<decltype parenthesized_expr>::type::type


### PR DESCRIPTION
Did not check myself. Versions below 3.0 I think do not matter. Problem found on https://www.boost.org/development/tests/develop/developer/output/teeks99-02-dc3-0-opt-Docker-64on64-boost-bin-v2-libs-spirit-test-lex-lex_token_moretypes-test-clang-linux-3-0~c++11~O2-debug.html