### PR TITLE
Adapt bimaps::relation::structured_pair, container::detail::pair, and compressed_pair

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,9 +184,11 @@ install:
 
   - git submodule init libs/array
   - git submodule init libs/assert
+  - git submodule init libs/bimap
   - git submodule init libs/bind
   - git submodule init libs/concept_check
   - git submodule init libs/config
+  - git submodule init libs/container
   - git submodule init libs/container_hash
   - git submodule init libs/conversion
   - git submodule init libs/core
@@ -195,6 +197,7 @@ install:
   - git submodule init libs/function_types
   - git submodule init libs/functional
   - git submodule init libs/integer
+  - git submodule init libs/intrusive
   - git submodule init libs/iterator
   - git submodule init libs/lambda
   - git submodule init libs/move

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,11 @@ install:
 
   - git submodule init libs/array
   - git submodule init libs/assert
+  - git submodule init libs/bimap
   - git submodule init libs/bind
   - git submodule init libs/concept_check
   - git submodule init libs/config
+  - git submodule init libs/container
   - git submodule init libs/container_hash
   - git submodule init libs/conversion
   - git submodule init libs/core
@@ -57,6 +59,7 @@ install:
   - git submodule init libs/function_types
   - git submodule init libs/functional
   - git submodule init libs/integer
+  - git submodule init libs/intrusive
   - git submodule init libs/iterator
   - git submodule init libs/lambda
   - git submodule init libs/move

--- a/include/boost/fusion/adapted.hpp
+++ b/include/boost/fusion/adapted.hpp
@@ -1,21 +1,25 @@
-/*=============================================================================
+/*============================================================================
     Copyright (c) 2001-2011 Joel de Guzman
     Copyright (c) 2005-2006 Dan Marsden
 
-    Distributed under the Boost Software License, Version 1.0. (See accompanying
-    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-==============================================================================*/
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
 #if !defined(BOOST_FUSION_ADAPTED_30122005_1420)
 #define BOOST_FUSION_ADAPTED_30122005_1420
 
-#include <boost/fusion/support/config.hpp>
 #include <boost/fusion/adapted/adt.hpp>
 #include <boost/fusion/adapted/array.hpp>
 #include <boost/fusion/adapted/boost_array.hpp>
 #include <boost/fusion/adapted/boost_tuple.hpp>
 #include <boost/fusion/adapted/mpl.hpp>
 #include <boost/fusion/adapted/std_pair.hpp>
+#include <boost/fusion/adapted/boost_bimap_pair.hpp>
+#include <boost/fusion/adapted/boost_compressed_pair.hpp>
+#include <boost/fusion/adapted/boost_container_pair.hpp>
 #include <boost/fusion/adapted/struct.hpp>
+#include <boost/fusion/support/config.hpp>
 
 // The std_tuple_iterator adaptor only supports implementations
 // using variadic templates
@@ -23,4 +27,5 @@
 #include <boost/fusion/adapted/std_tuple.hpp>
 #endif
 
-#endif
+#endif  // include guard
+

--- a/include/boost/fusion/adapted/boost_bimap_pair.hpp
+++ b/include/boost/fusion/adapted/boost_bimap_pair.hpp
@@ -1,0 +1,71 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#if !defined(BOOST_FUSION_ADAPTED_BOOST_BIMAP_PAIR_HPP)
+#define BOOST_FUSION_ADAPTED_BOOST_BIMAP_PAIR_HPP
+
+#include <boost/bimap/tags/support/default_tagged.hpp>
+#include <boost/bimap/relation/member_at.hpp>
+
+namespace boost { namespace fusion { namespace detail { namespace bimap_pair
+{
+    template <typename T>
+    struct first_type
+    {
+        typedef typename ::boost::bimaps::tags::support::default_tagged<
+            T
+          , ::boost::bimaps::relation::member_at::left
+        >::type::value_type type;
+    };
+
+    template <typename T>
+    struct second_type
+    {
+        typedef typename ::boost::bimaps::tags::support::default_tagged<
+            T
+          , ::boost::bimaps::relation::member_at::right
+        >::type::value_type type;
+    };
+}}}}
+
+#include <boost/bimap/relation/structured_pair.hpp>
+#include <boost/fusion/adapted/struct/adapt_struct.hpp>
+
+BOOST_FUSION_ADAPT_TPL_STRUCT(
+    (T1)(T2)
+  , (::boost::bimaps::relation::structured_pair)
+    (T1)
+    (T2)
+    (boost::bimaps::relation::normal_layout)
+  , (
+        typename ::boost::fusion::detail::bimap_pair::first_type<T1>::type
+      , first
+    )
+    (
+        typename ::boost::fusion::detail::bimap_pair::second_type<T2>::type
+      , second
+    )
+)
+
+BOOST_FUSION_ADAPT_TPL_STRUCT(
+    (T1)(T2)
+  , (::boost::bimaps::relation::structured_pair)
+    (T1)
+    (T2)
+    (boost::bimaps::relation::mirror_layout)
+  , (
+        typename ::boost::fusion::detail::bimap_pair::second_type<T2>::type
+      , second
+    )
+    (
+        typename ::boost::fusion::detail::bimap_pair::first_type<T1>::type
+      , first
+    )
+)
+
+#endif  // include guard
+

--- a/include/boost/fusion/adapted/boost_compressed_pair.hpp
+++ b/include/boost/fusion/adapted/boost_compressed_pair.hpp
@@ -1,0 +1,33 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#if !defined(BOOST_FUSION_ADAPTED_BOOST_COMPRESSED_PAIR_HPP)
+#define BOOST_FUSION_ADAPTED_BOOST_COMPRESSED_PAIR_HPP
+
+#include <boost/fusion/adapted/adt/adapt_adt.hpp>
+#include <boost/compressed_pair.hpp>
+#include <boost/call_traits.hpp>
+
+BOOST_FUSION_ADAPT_TPL_ADT(
+    (T1)(T2)
+  , (::boost::compressed_pair)(T1)(T2)
+  , (
+        typename ::boost::call_traits<T1>::reference
+      , typename ::boost::call_traits<T1>::const_reference
+      , obj.first()
+      , obj.first() = val
+    )
+    (
+        typename ::boost::call_traits<T2>::reference
+      , typename ::boost::call_traits<T2>::const_reference
+      , obj.second()
+      , obj.second() = val
+    )
+)
+
+#endif  // include guard
+

--- a/include/boost/fusion/adapted/boost_container_pair.hpp
+++ b/include/boost/fusion/adapted/boost_container_pair.hpp
@@ -1,0 +1,19 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#if !defined(BOOST_FUSION_ADAPTED_BOOST_CONTAINER_PAIR_HPP)
+#define BOOST_FUSION_ADAPTED_BOOST_CONTAINER_PAIR_HPP
+
+#include <boost/fusion/adapted/struct/adapt_struct.hpp>
+#include <boost/container/detail/pair.hpp>
+
+BOOST_FUSION_ADAPT_TPL_STRUCT(
+    (T1)(T2), (::boost::container::dtl::pair)(T1)(T2), (T1, first)(T2, second)
+)
+
+#endif  // include guard
+

--- a/include/boost/fusion/include/boost_bimap_pair.hpp
+++ b/include/boost/fusion/include/boost_bimap_pair.hpp
@@ -1,0 +1,14 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#if !defined(BOOST_FUSION_INCLUDE_BOOST_BIMAP_PAIR_HPP)
+#define BOOST_FUSION_INCLUDE_BOOST_BIMAP_PAIR_HPP
+
+#include <boost/fusion/adapted/boost_bimap_pair.hpp>
+
+#endif  // include guard
+

--- a/include/boost/fusion/include/boost_compressed_pair.hpp
+++ b/include/boost/fusion/include/boost_compressed_pair.hpp
@@ -1,0 +1,14 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#if !defined(BOOST_FUSION_INCLUDE_BOOST_COMPRESSED_PAIR_HPP)
+#define BOOST_FUSION_INCLUDE_BOOST_COMPRESSED_PAIR_HPP
+
+#include <boost/fusion/adapted/boost_compressed_pair.hpp>
+
+#endif  // include guard
+

--- a/include/boost/fusion/include/boost_container_pair.hpp
+++ b/include/boost/fusion/include/boost_container_pair.hpp
@@ -1,0 +1,14 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#if !defined(BOOST_FUSION_INCLUDE_BOOST_CONTAINER_PAIR_HPP)
+#define BOOST_FUSION_INCLUDE_BOOST_CONTAINER_PAIR_HPP
+
+#include <boost/fusion/adapted/boost_container_pair.hpp>
+
+#endif  // include guard
+

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -134,6 +134,9 @@ project
     [ run sequence/set.cpp ]
     [ run sequence/single_view.cpp ]
     [ run sequence/std_pair.cpp ]
+    [ run sequence/boost_bimap_pair.cpp ]
+    [ run sequence/boost_compressed_pair.cpp ]
+    [ run sequence/boost_container_pair.cpp ]
     [ run sequence/boost_array.cpp ]
     [ run sequence/array.cpp ]
     [ run sequence/std_array.cpp : :

--- a/test/sequence/adapted_pair.hpp
+++ b/test/sequence/adapted_pair.hpp
@@ -1,0 +1,106 @@
+/*============================================================================
+    Copyright (c) 2001-2011 Joel de Guzman
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#include <boost/fusion/sequence/comparison/less.hpp>
+#include <boost/fusion/sequence/comparison/less_equal.hpp>
+#include <boost/fusion/sequence/comparison/greater.hpp>
+#include <boost/fusion/sequence/comparison/greater_equal.hpp>
+#include <boost/fusion/container/vector/vector.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+namespace test
+{
+    template <typename PairType>
+    void pair_compare(PairType& p)
+    {
+        boost::fusion::vector<int, float> v1(4, 3.3f);
+        boost::fusion::vector<long, double> v2(5, 4.4);
+        BOOST_TEST(v1 < p);
+        BOOST_TEST(v1 <= p);
+        BOOST_TEST(p > v1);
+        BOOST_TEST(p >= v1);
+        BOOST_TEST(p < v2);
+        BOOST_TEST(p <= v2);
+        BOOST_TEST(v2 > p);
+        BOOST_TEST(v2 >= p);
+    }
+}
+
+#include <boost/fusion/sequence/comparison/equal_to.hpp>
+#include <boost/fusion/sequence/comparison/not_equal_to.hpp>
+#include <boost/fusion/sequence/intrinsic/empty.hpp>
+#include <boost/fusion/sequence/intrinsic/size.hpp>
+#include <boost/fusion/sequence/intrinsic/front.hpp>
+#include <boost/fusion/sequence/intrinsic/back.hpp>
+#include <boost/fusion/sequence/intrinsic/at.hpp>
+#include <boost/fusion/container/list/list.hpp>
+#include <boost/fusion/container/generation/make_vector.hpp>
+#include <boost/fusion/mpl.hpp>
+#include <boost/fusion/support/is_view.hpp>
+#include <boost/mpl/int.hpp>
+#include <boost/mpl/equal_to.hpp>
+#include <boost/mpl/is_sequence.hpp>
+#include <boost/mpl/front.hpp>
+#include <boost/mpl/back.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+namespace test
+{
+    template <typename PairType>
+    void pair_access_and_modify(PairType& p)
+    {
+        BOOST_MPL_ASSERT((boost::mpl::is_sequence<PairType>));
+        BOOST_MPL_ASSERT((
+            boost::is_same<int, typename boost::mpl::front<PairType>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<
+                std::string
+              , typename boost::mpl::back<PairType>::type
+            >
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<int, typename boost::mpl::at_c<PairType,0>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<
+                std::string
+              , typename boost::mpl::at_c<PairType,1>::type
+            >
+        ));
+        BOOST_MPL_ASSERT((
+            boost::mpl::equal_to<
+                boost::fusion::result_of::size<PairType>
+              , boost::mpl::int_<2>
+            >
+        ));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::traits::is_view<PairType>));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::result_of::empty<PairType>));
+
+        BOOST_TEST(p == boost::fusion::make_vector(123, "Hola!!!"));
+
+        boost::fusion::vector<int, std::string> v(p);
+        BOOST_TEST(v == p);
+        v = p;
+        BOOST_TEST(v == p);
+
+        boost::fusion::list<int, std::string> l(p);
+        BOOST_TEST(l == p);
+        l = p;
+        BOOST_TEST(l == p);
+
+        boost::fusion::at_c<0>(p) = 6;
+        boost::fusion::at_c<1>(p) = "mama mia";
+        BOOST_TEST(p == boost::fusion::make_vector(6, "mama mia"));
+        BOOST_TEST(boost::fusion::front(p) == 6);
+#if 0
+        BOOST_TEST(boost::fusion::back(p) == "mama mia");
+#endif
+    }
+}
+

--- a/test/sequence/boost_bimap_pair.cpp
+++ b/test/sequence/boost_bimap_pair.cpp
@@ -1,0 +1,54 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#include <boost/fusion/adapted/boost_bimap_pair.hpp>
+#include <string>
+#include "adapted_pair.hpp"
+
+int main()
+{
+    {
+        boost::bimaps::relation::structured_pair<
+            int
+          , std::string
+          , boost::bimaps::relation::normal_layout
+        > p(123, "Hola!!!");
+        test::pair_access_and_modify(p);
+        BOOST_TEST(boost::fusion::back(p) == "mama mia");
+    }
+
+    {
+        boost::bimaps::relation::structured_pair<
+            std::string
+          , int
+          , boost::bimaps::relation::mirror_layout
+        > p("Hola!!!", 123);
+        test::pair_access_and_modify(p);
+        BOOST_TEST(boost::fusion::back(p) == "mama mia");
+    }
+
+    {
+        boost::bimaps::relation::structured_pair<
+            short
+          , float
+          , boost::bimaps::relation::normal_layout
+        > p(5, 3.3f);
+        test::pair_compare(p);
+    }
+
+    {
+        boost::bimaps::relation::structured_pair<
+            float
+          , short
+          , boost::bimaps::relation::mirror_layout
+        > p(3.3f, 5);
+        test::pair_compare(p);
+    }
+
+    return boost::report_errors();
+}
+

--- a/test/sequence/boost_compressed_pair.cpp
+++ b/test/sequence/boost_compressed_pair.cpp
@@ -1,0 +1,170 @@
+/*============================================================================
+    Copyright (c) 2013-2018 Cromwell D. Enage
+
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+============================================================================*/
+#include <boost/fusion/adapted/boost_compressed_pair.hpp>
+#include <string>
+#include "adapted_pair.hpp"
+
+namespace test
+{
+    struct empty_base
+    {
+    };
+
+    bool operator==(empty_base const&, empty_base const&)
+    {
+        return true;
+    }
+
+    bool operator!=(empty_base const&, empty_base const&)
+    {
+        return false;
+    }
+}
+
+int main()
+{
+    {
+        boost::compressed_pair<int, std::string> p(123, "Hola!!!");
+        test::pair_access_and_modify(p);
+    }
+
+    {
+        boost::compressed_pair<short, float> p(5, 3.3f);
+        test::pair_compare(p);
+    }
+
+    {
+        typedef boost::compressed_pair<int, test::empty_base> pair_type;
+        BOOST_MPL_ASSERT((boost::mpl::is_sequence<pair_type>));
+        BOOST_MPL_ASSERT((
+            boost::is_same<int, boost::mpl::front<pair_type>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<
+                test::empty_base
+              , boost::mpl::back<pair_type>::type
+            >
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<int, boost::mpl::at_c<pair_type,0>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<
+                test::empty_base
+              , boost::mpl::at_c<pair_type,1>::type
+            >
+        ));
+        BOOST_MPL_ASSERT((
+            boost::mpl::equal_to<
+                boost::fusion::result_of::size<pair_type>
+              , boost::mpl::int_<2>
+            >
+        ));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::traits::is_view<pair_type>));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::result_of::empty<pair_type>));
+
+        pair_type p(123);
+        BOOST_TEST(boost::fusion::front(p) == 123);
+
+        boost::fusion::at_c<0>(p) = 6;
+        BOOST_TEST(boost::fusion::front(p) == 6);
+    }
+
+    {
+        typedef boost::compressed_pair<
+            test::empty_base
+          , std::string
+        > pair_type;
+        BOOST_MPL_ASSERT((boost::mpl::is_sequence<pair_type>));
+        BOOST_MPL_ASSERT((
+            boost::is_same<
+                test::empty_base
+              , boost::mpl::front<pair_type>::type
+            >
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<std::string, boost::mpl::back<pair_type>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<
+                test::empty_base
+              , boost::mpl::at_c<pair_type,0>::type
+            >
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<std::string, boost::mpl::at_c<pair_type,1>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::mpl::equal_to<
+                boost::fusion::result_of::size<pair_type>
+              , boost::mpl::int_<2>
+            >
+        ));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::traits::is_view<pair_type>));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::result_of::empty<pair_type>));
+
+        pair_type p("Hola!!!");
+        BOOST_TEST(
+            p == boost::fusion::make_vector(test::empty_base(), "Hola!!!")
+        );
+
+        boost::fusion::at_c<1>(p) = "mama mia";
+        BOOST_TEST(
+            p == boost::fusion::make_vector(test::empty_base(), "mama mia")
+        );
+    }
+
+    {
+        typedef boost::compressed_pair<short, short> pair_type;
+        BOOST_MPL_ASSERT((boost::mpl::is_sequence<pair_type>));
+        BOOST_MPL_ASSERT((
+            boost::is_same<short, boost::mpl::front<pair_type>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<short, boost::mpl::back<pair_type>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<short, boost::mpl::at_c<pair_type,0>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::is_same<short, boost::mpl::at_c<pair_type,1>::type>
+        ));
+        BOOST_MPL_ASSERT((
+            boost::mpl::equal_to<
+                boost::fusion::result_of::size<pair_type>
+              , boost::mpl::int_<2>
+            >
+        ));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::traits::is_view<pair_type>));
+        BOOST_MPL_ASSERT_NOT((boost::fusion::result_of::empty<pair_type>));
+
+        pair_type p(456);
+        BOOST_TEST(p == boost::fusion::make_vector(456, 456));
+
+        boost::fusion::vector<short, short> v(p);
+        BOOST_TEST(v == p);
+        v = p;
+        BOOST_TEST(v == p);
+
+        boost::fusion::list<short, short> l(p);
+        BOOST_TEST(l == p);
+        l = p;
+        BOOST_TEST(l == p);
+
+        boost::fusion::at_c<0>(p) = 7;
+        boost::fusion::at_c<1>(p) = 8;
+        BOOST_TEST(p == boost::fusion::make_vector(7, 8));
+        BOOST_TEST(boost::fusion::front(p) == 7);
+#if 0
+        BOOST_TEST(boost::fusion::back(p) == 8);
+#endif
+    }
+
+    return boost::report_errors();
+}
+

--- a/test/sequence/boost_container_pair.cpp
+++ b/test/sequence/boost_container_pair.cpp
@@ -1,24 +1,27 @@
 /*============================================================================
-    Copyright (c) 2001-2011 Joel de Guzman
+    Copyright (c) 2013-2018 Cromwell D. Enage
 
     Distributed under the Boost Software License, Version 1.0.
     (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt)
 ============================================================================*/
-#include <boost/fusion/adapted/std_pair.hpp>
+#include <boost/fusion/adapted/boost_container_pair.hpp>
+#include <boost/container/map.hpp>
 #include <string>
 #include "adapted_pair.hpp"
 
 int main()
 {
     {
-        std::pair<int, std::string> p(123, "Hola!!!");
+        boost::container::map<int, std::string>
+        ::movable_value_type p(123, "Hola!!!");
         test::pair_access_and_modify(p);
         BOOST_TEST(boost::fusion::back(p) == "mama mia");
     }
 
     {
-        std::pair<short, float> p(5, 3.3f);
+        boost::container::map<short, float>
+        ::movable_value_type p(5, 3.3f);
         test::pair_compare(p);
     }
 


### PR DESCRIPTION
Recognize boost::bimaps::relation::structured_pair, boost::container::detail::pair, and boost::compressed_pair as Fusion sequences.