### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Copyright 2018 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# Partial (add_subdirectory only) and experimental CMake support
+# Subject to change; please do not rely on the contents of this file yet
 
 cmake_minimum_required(VERSION 3.5)
 project(BoostFusion LANGUAGES CXX)
@@ -11,16 +14,16 @@ add_library(Boost::fusion ALIAS boost_fusion)
 target_include_directories(boost_fusion INTERFACE include)
 
 target_link_libraries(boost_fusion
-	INTERFACE
-		Boost::config
-		Boost::container_hash
-		Boost::core
-		Boost::function_types
-		Boost::mpl
-		Boost::preprocessor
-		Boost::static_assert
-		Boost::tuple
-		Boost::type_traits
-		Boost::typeof
-		Boost::utility
+    INTERFACE
+        Boost::config
+        Boost::container_hash
+        Boost::core
+        Boost::function_types
+        Boost::mpl
+        Boost::preprocessor
+        Boost::static_assert
+        Boost::tuple
+        Boost::type_traits
+        Boost::typeof
+        Boost::utility
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostFusion LANGUAGES CXX)
+
+add_library(boost_fusion INTERFACE)
+add_library(Boost::fusion ALIAS boost_fusion)
+
+target_include_directories(boost_fusion INTERFACE include)
+
+target_link_libraries(boost_fusion
+	INTERFACE
+		Boost::config
+		Boost::container_hash
+		Boost::core
+		Boost::function_types
+		Boost::mpl
+		Boost::preprocessor
+		Boost::static_assert
+		Boost::tuple
+		Boost::type_traits
+		Boost::typeof
+		Boost::utility
+)


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling (Providedthat also all dependencies where added to the project before):

    add_subdirectory( <path-to-boost_fusion> ) 
    target_link_libraries( <my_lib> PUBLIC Boost::fusion )


More information:

- https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M
- https://groups.google.com/d/msg/boost-developers-archive/4HU-RzReL7U/FS1X6OFrEQAJ
- https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU

Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.

Note: The cmake file depends on https://github.com/boostorg/mpl/pull/40, but I expect this to get merged soon, so I think there is no harm in merging this PR already.