### PR TITLE
Explicitly delete all non implemented assignment operators.

### DIFF
--- a/include/boost/fusion/adapted/boost_tuple/boost_tuple_iterator.hpp
+++ b/include/boost/fusion/adapted/boost_tuple/boost_tuple_iterator.hpp
@@ -144,9 +144,8 @@ namespace boost { namespace fusion
             : is_same<typename I1::identity, typename I2::identity>
         {};
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        boost_tuple_iterator& operator= (boost_tuple_iterator const&);
+        BOOST_DELETED_FUNCTION(boost_tuple_iterator& operator= (boost_tuple_iterator const&))
     };
 
     template <typename Null>

--- a/include/boost/fusion/container/deque/deque_iterator.hpp
+++ b/include/boost/fusion/container/deque/deque_iterator.hpp
@@ -111,9 +111,8 @@ namespace boost { namespace fusion {
 
         Seq& seq_;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        deque_iterator& operator= (deque_iterator const&);
+        BOOST_DELETED_FUNCTION(deque_iterator& operator= (deque_iterator const&))
     };
 
 }}

--- a/include/boost/fusion/container/list/cons_iterator.hpp
+++ b/include/boost/fusion/container/list/cons_iterator.hpp
@@ -42,9 +42,8 @@ namespace boost { namespace fusion
 
         cons_type& cons;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        cons_iterator& operator= (cons_iterator const&);
+        BOOST_DELETED_FUNCTION(cons_iterator& operator= (cons_iterator const&))
     };
 
     struct nil_iterator : iterator_base<nil_iterator>

--- a/include/boost/fusion/container/map/map_iterator.hpp
+++ b/include/boost/fusion/container/map/map_iterator.hpp
@@ -156,9 +156,8 @@ namespace boost { namespace fusion
 
         Seq& seq_;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        map_iterator& operator= (map_iterator const&);
+        BOOST_DELETED_FUNCTION(map_iterator& operator= (map_iterator const&))
     };
 
 }}

--- a/include/boost/fusion/container/vector/vector_iterator.hpp
+++ b/include/boost/fusion/container/vector/vector_iterator.hpp
@@ -43,9 +43,8 @@ namespace boost { namespace fusion
 
         Vector& vec;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        vector_iterator& operator= (vector_iterator const&);
+        BOOST_DELETED_FUNCTION(vector_iterator& operator= (vector_iterator const&))
     };
 }}
 

--- a/include/boost/fusion/sequence/io/detail/manip.hpp
+++ b/include/boost/fusion/sequence/io/detail/manip.hpp
@@ -144,9 +144,8 @@ namespace boost { namespace fusion
 
             Stream& stream;
 
-        private:
             // silence MSVC warning C4512: assignment operator could not be generated
-            string_ios_manip& operator= (string_ios_manip const&);
+            BOOST_DELETED_FUNCTION(string_ios_manip& operator= (string_ios_manip const&))
         };
 
     } // detail

--- a/include/boost/fusion/view/filter_view/filter_view.hpp
+++ b/include/boost/fusion/view/filter_view/filter_view.hpp
@@ -57,9 +57,8 @@ namespace boost { namespace fusion
         last_type last() const { return fusion::end(seq); }
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        filter_view& operator= (filter_view const&);
+        BOOST_DELETED_FUNCTION(filter_view& operator= (filter_view const&))
     };
 }}
 

--- a/include/boost/fusion/view/filter_view/filter_view_iterator.hpp
+++ b/include/boost/fusion/view/filter_view/filter_view_iterator.hpp
@@ -61,9 +61,8 @@ namespace boost { namespace fusion
 
         first_type first;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        filter_iterator& operator= (filter_iterator const&);
+        BOOST_DELETED_FUNCTION(filter_iterator& operator= (filter_iterator const&))
     };
 }}
 

--- a/include/boost/fusion/view/joint_view/joint_view.hpp
+++ b/include/boost/fusion/view/joint_view/joint_view.hpp
@@ -69,10 +69,10 @@ namespace boost { namespace fusion
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         concat_last_type concat_last() const { return fusion::end(seq2); }
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        joint_view& operator= (joint_view const&);
+        BOOST_DELETED_FUNCTION(joint_view& operator= (joint_view const&))
 
+    private:
         typename mpl::if_<traits::is_view<Sequence1>, Sequence1, Sequence1&>::type seq1;
         typename mpl::if_<traits::is_view<Sequence2>, Sequence2, Sequence2&>::type seq2;
     };

--- a/include/boost/fusion/view/joint_view/joint_view_iterator.hpp
+++ b/include/boost/fusion/view/joint_view/joint_view_iterator.hpp
@@ -50,9 +50,8 @@ namespace boost { namespace fusion
         first_type first;
         concat_type concat;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        joint_view_iterator& operator= (joint_view_iterator const&);
+        BOOST_DELETED_FUNCTION(joint_view_iterator& operator= (joint_view_iterator const&))
     };
 }}
 

--- a/include/boost/fusion/view/nview/nview_iterator.hpp
+++ b/include/boost/fusion/view/nview/nview_iterator.hpp
@@ -47,9 +47,8 @@ namespace boost { namespace fusion
 
         Sequence& seq;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        nview_iterator& operator= (nview_iterator const&);
+        BOOST_DELETED_FUNCTION(nview_iterator& operator= (nview_iterator const&))
     };
 
 }}

--- a/include/boost/fusion/view/repetitive_view/repetitive_view.hpp
+++ b/include/boost/fusion/view/repetitive_view/repetitive_view.hpp
@@ -44,9 +44,8 @@ namespace boost { namespace fusion
 
         stored_seq_type seq;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        repetitive_view& operator= (repetitive_view const&);
+        BOOST_DELETED_FUNCTION(repetitive_view& operator= (repetitive_view const&))
     };
 
 }}

--- a/include/boost/fusion/view/repetitive_view/repetitive_view_iterator.hpp
+++ b/include/boost/fusion/view/repetitive_view/repetitive_view_iterator.hpp
@@ -47,9 +47,8 @@ namespace boost { namespace fusion
         Sequence& seq;
         pos_type pos;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        repetitive_view_iterator& operator= (repetitive_view_iterator const&);
+        BOOST_DELETED_FUNCTION(repetitive_view_iterator& operator= (repetitive_view_iterator const&))
     };
 }}
 

--- a/include/boost/fusion/view/reverse_view/reverse_view.hpp
+++ b/include/boost/fusion/view/reverse_view/reverse_view.hpp
@@ -61,9 +61,8 @@ namespace boost { namespace fusion
         last_type last() const { return fusion::end(seq); }
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        reverse_view& operator= (reverse_view const&);
+        BOOST_DELETED_FUNCTION(reverse_view& operator= (reverse_view const&))
     };
 }}
 

--- a/include/boost/fusion/view/reverse_view/reverse_view_iterator.hpp
+++ b/include/boost/fusion/view/reverse_view/reverse_view_iterator.hpp
@@ -48,9 +48,8 @@ namespace boost { namespace fusion
 
         first_type first;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        reverse_view_iterator& operator= (reverse_view_iterator const&);
+        BOOST_DELETED_FUNCTION(reverse_view_iterator& operator= (reverse_view_iterator const&))
     };
 }}
 

--- a/include/boost/fusion/view/transform_view/transform_view.hpp
+++ b/include/boost/fusion/view/transform_view/transform_view.hpp
@@ -76,9 +76,8 @@ namespace boost { namespace fusion
         typename mpl::if_<traits::is_view<Sequence1>, Sequence1, Sequence1&>::type seq1;
         typename mpl::if_<traits::is_view<Sequence2>, Sequence2, Sequence2&>::type seq2;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        transform_view& operator= (transform_view const&);
+        BOOST_DELETED_FUNCTION(transform_view& operator= (transform_view const&))
     };
 
     // Unary Version
@@ -113,9 +112,8 @@ namespace boost { namespace fusion
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
         transform_type f;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        transform_view& operator= (transform_view const&);
+        BOOST_DELETED_FUNCTION(transform_view& operator= (transform_view const&))
     };
 }}
 

--- a/include/boost/fusion/view/transform_view/transform_view_iterator.hpp
+++ b/include/boost/fusion/view/transform_view/transform_view_iterator.hpp
@@ -42,9 +42,8 @@ namespace boost { namespace fusion
         first_type first;
         transform_type f;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        transform_view_iterator& operator= (transform_view_iterator const&);
+        BOOST_DELETED_FUNCTION(transform_view_iterator& operator= (transform_view_iterator const&))
     };
 
     // Binary Version
@@ -70,9 +69,8 @@ namespace boost { namespace fusion
         first2_type first2;
         transform_type f;
 
-    private:
         // silence MSVC warning C4512: assignment operator could not be generated
-        transform_view_iterator2& operator= (transform_view_iterator2 const&);
+        BOOST_DELETED_FUNCTION(transform_view_iterator2& operator= (transform_view_iterator2 const&))
     };
 }}
 


### PR DESCRIPTION
Commit (almost) automatically generated with the following sed command:
sed -i -ne '1h;1!H;${g;s|\n[[:blank:]]*private:\n\([[:blank:]]*\)// silence MSVC warning C4512: assignment operator could not be generated\n\([[:blank:]]*\)\([^\n]\+\);\n|\n\1// silence MSVC warning C4512: assignment operator could not be generated\n\2BOOST_DELETED_FUNCTION(\3);\n|g;p}' $(git ls-files)

Hi,

This is needed to silence some gcc 9 warnings about deprecated implicit copy ctor/operators.

See the discussion we had in https://github.com/boostorg/spirit/pull/488 and the similar pull request that was merged in Boost Spirit here: https://github.com/boostorg/spirit/pull/489

FYI @Kojoley 

Cheers,
Romain 