### PR TITLE
Fix comparison operators enabler

### DIFF
--- a/include/boost/fusion/sequence/comparison/enable_comparison.hpp
+++ b/include/boost/fusion/sequence/comparison/enable_comparison.hpp
@@ -20,13 +20,13 @@ namespace boost { namespace fusion { namespace traits
 {
     template <typename Seq1, typename Seq2, typename Enable = void>
     struct enable_equality
-        : mpl::or_<traits::is_sequence<Seq1>, traits::is_sequence<Seq2> >
+        : mpl::and_<traits::is_sequence<Seq1>, traits::is_sequence<Seq2> >
     {};
 
     template <typename Seq1, typename Seq2, typename Enable = void>
     struct enable_comparison
         : mpl::and_<
-            mpl::or_<traits::is_sequence<Seq1>, traits::is_sequence<Seq2> >
+            traits::is_sequence<Seq1>, traits::is_sequence<Seq2>
           , mpl::equal_to<result_of::size<Seq1>, result_of::size<Seq2> >
         >
     {};

--- a/test/sequence/comparison.hpp
+++ b/test/sequence/comparison.hpp
@@ -8,6 +8,20 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/fusion/sequence/comparison.hpp>
 
+struct not_a_fusion_container {};
+template <typename T>
+inline bool operator==(not_a_fusion_container, T const&) { return true; }
+template <typename T>
+inline bool operator!=(not_a_fusion_container, T const&) { return true; }
+template <typename T>
+inline bool operator<(not_a_fusion_container, T const&) { return true; }
+template <typename T>
+inline bool operator<=(not_a_fusion_container, T const&) { return true; }
+template <typename T>
+inline bool operator>(not_a_fusion_container, T const&) { return true; }
+template <typename T>
+inline bool operator>=(not_a_fusion_container, T const&) { return true; }
+
 void
 equality_test()
 {
@@ -28,6 +42,9 @@ equality_test()
     BOOST_TEST(!(v1 == v5));
     BOOST_TEST(v5 != v1);
     BOOST_TEST(!(v5 == v1));
+
+    BOOST_TEST(not_a_fusion_container() == v1);
+    BOOST_TEST(not_a_fusion_container() != v1);
 }
 
 void
@@ -51,6 +68,11 @@ ordering_test()
     FUSION_SEQUENCE<int, char, bool> v5(5, 'a', true);
     v1 >= v5;
 #endif
+
+    BOOST_TEST(not_a_fusion_container() > v1);
+    BOOST_TEST(not_a_fusion_container() >= v1);
+    BOOST_TEST(not_a_fusion_container() < v1);
+    BOOST_TEST(not_a_fusion_container() <= v1);
 }
 
 


### PR DESCRIPTION
Overloads must not be presented until both arguments are Fusion sequences.