### PR TITLE
Fix missing name copyright headers.

### DIFF
--- a/include/boost/fusion/algorithm/query/count.hpp
+++ b/include/boost/fusion/algorithm/query/count.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2001-2011 Joel de Guzman
-    Copyright (c) 2007
+    Copyright (c) 2007 Dan Marsden
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying 
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/sequence/deque_mutate.cpp
+++ b/test/sequence/deque_mutate.cpp
@@ -1,7 +1,7 @@
 /*=============================================================================
     Copyright (c) 1999-2003 Jaakko Jarvi
     Copyright (c) 2001-2011 Joel de Guzman
-    Copyright (c) 2006
+    Copyright (c) 2006 Dan Marsden
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying 
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/sequence/map_mutate.cpp
+++ b/test/sequence/map_mutate.cpp
@@ -1,7 +1,7 @@
 /*=============================================================================
     Copyright (c) 1999-2003 Jaakko Jarvi
     Copyright (c) 2001-2011 Joel de Guzman
-    Copyright (c) 2006
+    Copyright (c) 2006 Dan Marsden
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
The name was reconstructed from the Git history.