### PR TITLE
Fixed reverse_view

### DIFF
--- a/include/boost/fusion/view/reverse_view/detail/deref_data_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/deref_data_impl.hpp
@@ -10,7 +10,8 @@
 #define BOOST_FUSION_VIEW_REVERSE_VIEW_DETAIL_DEREF_DATA_IMPL_HPP
 
 #include <boost/fusion/support/config.hpp>
-#include <boost/fusion/view/reverse_view/detail/deref_impl.hpp>
+#include <boost/fusion/iterator/deref_data.hpp>
+#include <boost/fusion/iterator/prior.hpp>
 
 namespace boost { namespace fusion { namespace extension
 {
@@ -19,8 +20,26 @@ namespace boost { namespace fusion { namespace extension
 
     template <>
     struct deref_data_impl<reverse_view_iterator_tag>
-    : deref_impl<reverse_view_iterator_tag>
-        {};
+    {
+        template <typename Iterator>
+        struct apply
+        {
+            typedef typename
+                result_of::deref_data<
+                    typename result_of::prior<
+                        typename Iterator::first_type
+                    >::type
+                >::type
+            type;
+
+            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+            static type
+            call(Iterator const& i)
+            {
+                return fusion::deref_data(fusion::prior(i.first));
+            }
+        };
+    };
 }}}
 
 #endif

--- a/include/boost/fusion/view/reverse_view/detail/deref_data_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/deref_data_impl.hpp
@@ -1,5 +1,6 @@
 /*=============================================================================
     Copyright (c) 2009 Christopher Schmidt
+    Copyright (c) 2021 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,7 +10,7 @@
 #define BOOST_FUSION_VIEW_REVERSE_VIEW_DETAIL_DEREF_DATA_IMPL_HPP
 
 #include <boost/fusion/support/config.hpp>
-#include <boost/fusion/iterator/deref_data.hpp>
+#include <boost/fusion/view/reverse_view/detail/deref_impl.hpp>
 
 namespace boost { namespace fusion { namespace extension
 {
@@ -18,22 +19,8 @@ namespace boost { namespace fusion { namespace extension
 
     template <>
     struct deref_data_impl<reverse_view_iterator_tag>
-    {
-        template <typename It>
-        struct apply
-        {
-            typedef typename
-                result_of::deref_data<typename It::first_type>::type
-            type;
-
-            BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-            static type
-            call(It const& it)
-            {
-                return fusion::deref_data(it.first);
-            }
-        };
-    };
+    : deref_impl<reverse_view_iterator_tag>
+        {};
 }}}
 
 #endif

--- a/include/boost/fusion/view/reverse_view/detail/deref_data_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/deref_data_impl.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2009 Christopher Schmidt
-    Copyright (c) 2021 Denis Mikhailov
+    Copyright (c) 2021-2022 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -21,22 +21,22 @@ namespace boost { namespace fusion { namespace extension
     template <>
     struct deref_data_impl<reverse_view_iterator_tag>
     {
-        template <typename Iterator>
+        template <typename It>
         struct apply
         {
             typedef typename
                 result_of::deref_data<
                     typename result_of::prior<
-                        typename Iterator::first_type
+                        typename It::first_type
                     >::type
                 >::type
             type;
 
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
             static type
-            call(Iterator const& i)
+            call(It const& it)
             {
-                return fusion::deref_data(fusion::prior(i.first));
+                return fusion::deref_data(fusion::prior(it.first));
             }
         };
     };

--- a/include/boost/fusion/view/reverse_view/detail/key_of_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/key_of_impl.hpp
@@ -1,5 +1,6 @@
 /*=============================================================================
     Copyright (c) 2009 Christopher Schmidt
+    Copyright (c) 2021 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +11,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/iterator/key_of.hpp>
+#include <boost/fusion/iterator/prior.hpp>
 
 namespace boost { namespace fusion { namespace extension
 {
@@ -21,8 +23,15 @@ namespace boost { namespace fusion { namespace extension
     {
         template <typename It>
         struct apply
-          : result_of::key_of<typename It::it_type>
-        {};
+        {
+            typedef typename
+                result_of::key_of<
+                    typename result_of::prior<
+                        typename It::first_type
+                    >::type
+                >::type
+            type;
+        };
     };
 }}}
 

--- a/include/boost/fusion/view/reverse_view/detail/key_of_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/key_of_impl.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2009 Christopher Schmidt
-    Copyright (c) 2021 Denis Mikhailov
+    Copyright (c) 2021-2022 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/fusion/view/reverse_view/detail/value_of_data_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/value_of_data_impl.hpp
@@ -11,7 +11,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/iterator/value_of_data.hpp>
-#include <boost/fusion/view/reverse_view/detail/value_of_impl.hpp>
+#include <boost/fusion/iterator/prior.hpp>
 
 namespace boost { namespace fusion { namespace extension
 {
@@ -21,10 +21,17 @@ namespace boost { namespace fusion { namespace extension
     template <>
     struct value_of_data_impl<reverse_view_iterator_tag>
     {
-        template <typename It>
+        template <typename Iterator>
         struct apply
-          : value_of_impl<reverse_view_iterator_tag>
-        {};
+        {
+            typedef typename
+                result_of::value_of_data<
+                    typename result_of::prior<
+                        typename Iterator::first_type
+                    >::type
+                >::type
+            type;
+        };
     };
 }}}
 

--- a/include/boost/fusion/view/reverse_view/detail/value_of_data_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/value_of_data_impl.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2009 Christopher Schmidt
-    Copyright (c) 2021 Denis Mikhailov
+    Copyright (c) 2021-2022 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -21,13 +21,13 @@ namespace boost { namespace fusion { namespace extension
     template <>
     struct value_of_data_impl<reverse_view_iterator_tag>
     {
-        template <typename Iterator>
+        template <typename It>
         struct apply
         {
             typedef typename
                 result_of::value_of_data<
                     typename result_of::prior<
-                        typename Iterator::first_type
+                        typename It::first_type
                     >::type
                 >::type
             type;

--- a/include/boost/fusion/view/reverse_view/detail/value_of_data_impl.hpp
+++ b/include/boost/fusion/view/reverse_view/detail/value_of_data_impl.hpp
@@ -1,5 +1,6 @@
 /*=============================================================================
     Copyright (c) 2009 Christopher Schmidt
+    Copyright (c) 2021 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +11,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/iterator/value_of_data.hpp>
+#include <boost/fusion/view/reverse_view/detail/value_of_impl.hpp>
 
 namespace boost { namespace fusion { namespace extension
 {
@@ -21,7 +23,7 @@ namespace boost { namespace fusion { namespace extension
     {
         template <typename It>
         struct apply
-          : result_of::value_of_data<typename It::first_type>
+          : value_of_impl<reverse_view_iterator_tag>
         {};
     };
 }}}

--- a/test/sequence/reverse_view.cpp
+++ b/test/sequence/reverse_view.cpp
@@ -15,6 +15,9 @@
 #include <boost/fusion/sequence/intrinsic/begin.hpp>
 #include <boost/fusion/sequence/intrinsic/at.hpp>
 #include <boost/fusion/sequence/intrinsic/value_at.hpp>
+#include <boost/fusion/sequence/intrinsic/has_key.hpp>
+#include <boost/fusion/sequence/intrinsic/at_key.hpp>
+#include <boost/fusion/sequence/intrinsic/value_at_key.hpp>
 #include <boost/fusion/iterator/next.hpp>
 #include <boost/fusion/iterator/prior.hpp>
 #include <boost/fusion/iterator/deref.hpp>

--- a/test/sequence/reverse_view.cpp
+++ b/test/sequence/reverse_view.cpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2001-2011 Joel de Guzman
-    Copyright (c) 2021 Denis Mikhailov
+    Copyright (c) 2021-2022 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying 
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/sequence/reverse_view.cpp
+++ b/test/sequence/reverse_view.cpp
@@ -102,6 +102,21 @@ main()
         BOOST_TEST((at_c<2>(rev) == pair2("two")));
         BOOST_TEST((at_c<3>(rev) == pair1("one")));
         BOOST_TEST((at_c<4>(rev) == pair0("zero")));
+        BOOST_TEST(( has_key< boost::mpl::int_<0> >(rev) 
+                  && has_key< boost::mpl::int_<4> >(rev) 
+                 && !has_key< boost::mpl::int_<-1> >(rev) 
+                 && !has_key< boost::mpl::int_<5> >(rev) ));
+        BOOST_TEST((at_key< boost::mpl::int_<0> >(rev) == "zero"));
+        BOOST_TEST((at_key< boost::mpl::int_<1> >(rev) == "one"));
+        BOOST_TEST((at_key< boost::mpl::int_<2> >(rev) == "two"));
+        BOOST_TEST((at_key< boost::mpl::int_<3> >(rev) == "three"));
+        BOOST_TEST((at_key< boost::mpl::int_<4> >(rev) == "four"));
+        BOOST_TEST(( (at_key< boost::mpl::int_<0> >(rev) = "new_zero") == "new_zero"
+                   && at_key< boost::mpl::int_<0> >(rev) == "new_zero" ));
+        BOOST_MPL_ASSERT((boost::mpl::and_<result_of::has_key<view_type, boost::mpl::int_<0> >
+                        , boost::mpl::not_<result_of::has_key<view_type, boost::mpl::int_<-1> > > >));
+        BOOST_MPL_ASSERT((boost::is_same<result_of::at_key<view_type, boost::mpl::int_<0>>::type, std::string&>));
+        BOOST_MPL_ASSERT((boost::is_same<result_of::value_at_key<view_type, boost::mpl::int_<0> >::type, std::string>));
     }
 
     return boost::report_errors();

--- a/test/sequence/reverse_view.cpp
+++ b/test/sequence/reverse_view.cpp
@@ -1,5 +1,6 @@
 /*=============================================================================
     Copyright (c) 2001-2011 Joel de Guzman
+    Copyright (c) 2021 Denis Mikhailov
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying 
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
The problem in question is "impossibility to apply any associative functions to `reverse_view`".
I keep getting errors like this when I try, for example, to apply `at_key` over `reverse_view`:
`/opt/compiler-explorer/libs/boost_1_77_0/boost/fusion/view/reverse_view/detail/key_of_impl.hpp:23:16: error: no type named 'it_type'`

More detailed example here:
https://godbolt.org/z/evqv4z9an
