### PR TITLE
refactor: remove some usage of deprecated headers

### DIFF
--- a/example/cookbook/do_the_bind.cpp
+++ b/example/cookbook/do_the_bind.cpp
@@ -46,7 +46,7 @@
 #include <boost/mpl/max.hpp>
 #include <boost/mpl/next.hpp>
 
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #include <iostream>
 #include <typeinfo>
 

--- a/include/boost/fusion/support/deduce.hpp
+++ b/include/boost/fusion/support/deduce.hpp
@@ -10,7 +10,7 @@
 #define BOOST_FUSION_SUPPORT_DEDUCE_HPP_INCLUDED
 
 #include <boost/fusion/support/config.hpp>
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 
 #ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
 #include <functional>

--- a/include/boost/fusion/support/detail/as_fusion_element.hpp
+++ b/include/boost/fusion/support/detail/as_fusion_element.hpp
@@ -9,7 +9,7 @@
 #define FUSION_AS_FUSION_ELEMENT_05052005_0338
 
 #include <boost/fusion/support/config.hpp>
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 
 #ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
 #include <functional>

--- a/test/functional/fused.cpp
+++ b/test/functional/fused.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/adapter/fused.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/fusion/container/generation/make_vector.hpp>
 #include <boost/fusion/container/vector.hpp>

--- a/test/functional/fused_function_object.cpp
+++ b/test/functional/fused_function_object.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/adapter/fused_function_object.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/mpl/empty_base.hpp>
 
 #include <boost/fusion/container/generation/make_vector.hpp>

--- a/test/functional/fused_procedure.cpp
+++ b/test/functional/fused_procedure.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/adapter/fused_procedure.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/mpl/empty_base.hpp>
 
 #include <boost/fusion/container/generation/make_vector.hpp>

--- a/test/functional/invoke.cpp
+++ b/test/functional/invoke.cpp
@@ -16,7 +16,7 @@
 #endif
 
 #include <memory>
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/type_traits/is_same.hpp>
 

--- a/test/functional/invoke_function_object.cpp
+++ b/test/functional/invoke_function_object.cpp
@@ -17,7 +17,7 @@
 #include <boost/type_traits/is_same.hpp>
 
 #include <memory>
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/mpl/int.hpp>
 

--- a/test/functional/invoke_procedure.cpp
+++ b/test/functional/invoke_procedure.cpp
@@ -16,7 +16,7 @@
 #endif
 
 #include <memory>
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/mpl/int.hpp>
 

--- a/test/functional/make_fused.cpp
+++ b/test/functional/make_fused.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/generation/make_fused.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/mpl/empty_base.hpp>
 
 #include <boost/fusion/container/generation/make_vector.hpp>

--- a/test/functional/make_fused_function_object.cpp
+++ b/test/functional/make_fused_function_object.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/generation/make_fused_function_object.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/mpl/empty_base.hpp>
 
 #include <boost/fusion/container/generation/make_vector.hpp>

--- a/test/functional/make_fused_procedure.cpp
+++ b/test/functional/make_fused_procedure.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/generation/make_fused_procedure.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/mpl/empty_base.hpp>
 
 #include <boost/fusion/container/generation/make_vector.hpp>

--- a/test/functional/make_unfused.cpp
+++ b/test/functional/make_unfused.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/generation/make_unfused.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/mpl/empty_base.hpp>
 #include <boost/mpl/if.hpp>

--- a/test/functional/make_unfused.cpp
+++ b/test/functional/make_unfused.cpp
@@ -19,11 +19,11 @@
 
 #include <boost/utility/result_of.hpp>
 #include <boost/core/enable_if.hpp>
+#include <boost/core/ref.hpp>
 
 #include <boost/fusion/sequence/intrinsic/empty.hpp>
 #include <boost/fusion/algorithm/iteration/fold.hpp>
 
-#include <boost/ref.hpp>
 
 namespace fusion = boost::fusion;
 namespace mpl = boost::mpl;

--- a/test/functional/unfused.cpp
+++ b/test/functional/unfused.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/adapter/unfused.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/mpl/empty_base.hpp>
 #include <boost/mpl/identity.hpp>

--- a/test/functional/unfused_typed.cpp
+++ b/test/functional/unfused_typed.cpp
@@ -9,7 +9,7 @@
 #include <boost/fusion/functional/adapter/unfused_typed.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 #include <boost/mpl/empty_base.hpp>
 #include <boost/mpl/identity.hpp>

--- a/test/sequence/deduce_sequence.cpp
+++ b/test/sequence/deduce_sequence.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/mpl/equal.hpp>
 
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #ifndef BOOST_NO_CXX11_HDR_FUNCTIONAL
 #include <functional>
 #endif


### PR DESCRIPTION
<boost/noncopyable.hpp> -> <boost/core/noncopyable.hpp>
<boost/ref.hpp> -> <boost/core/ref.hpp>