### PR TITLE
Fix Clang 13 `-Wdeprecated-copy` warnings

### DIFF
--- a/include/boost/fusion/adapted/boost_array/array_iterator.hpp
+++ b/include/boost/fusion/adapted/boost_array/array_iterator.hpp
@@ -18,6 +18,11 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/fusion/iterator/iterator_facade.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct random_access_traversal_tag;
@@ -102,10 +107,12 @@ namespace boost { namespace fusion
                 return type();
             }
         };
-
-        BOOST_DELETED_FUNCTION(array_iterator& operator=(array_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/adapted/boost_tuple/boost_tuple_iterator.hpp
+++ b/include/boost/fusion/adapted/boost_tuple/boost_tuple_iterator.hpp
@@ -45,6 +45,10 @@ namespace boost { namespace fusion
     template <typename Cons>
     struct boost_tuple_iterator_identity;
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
     template <typename Cons = tuples::null_type>
     struct boost_tuple_iterator
         : iterator_facade<boost_tuple_iterator<Cons>, forward_traversal_tag>
@@ -143,10 +147,10 @@ namespace boost { namespace fusion
         struct equal_to
             : is_same<typename I1::identity, typename I2::identity>
         {};
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(boost_tuple_iterator& operator= (boost_tuple_iterator const&))
     };
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
     template <typename Null>
     struct boost_tuple_null_iterator

--- a/include/boost/fusion/adapted/std_array/std_array_iterator.hpp
+++ b/include/boost/fusion/adapted/std_array/std_array_iterator.hpp
@@ -19,6 +19,11 @@
 #include <boost/fusion/iterator/iterator_facade.hpp>
 #include <boost/fusion/adapted/std_array/detail/array_size.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct random_access_traversal_tag;
@@ -99,9 +104,11 @@ namespace boost { namespace fusion
                 return type();
             }
         };
-
-        BOOST_DELETED_FUNCTION(std_array_iterator& operator=(std_array_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/fusion/adapted/std_tuple/std_tuple_iterator.hpp
+++ b/include/boost/fusion/adapted/std_tuple/std_tuple_iterator.hpp
@@ -17,6 +17,11 @@
 #include <tuple>
 #include <utility>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct random_access_traversal_tag;
@@ -106,6 +111,10 @@ namespace boost { namespace fusion
         };
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
+++ b/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
@@ -326,6 +326,9 @@
 #define BOOST_FUSION_DEFINE_STRUCT_INLINE_ITERATOR_IMPL_IMPL(                   \
     NAME, ATTRIBUTES_SEQ, ATTRIBUTES_SEQ_SIZE)                                  \
                                                                                 \
+    BOOST_FUSION_PUSH_WARNINGS                                                  \
+    BOOST_FUSION_DISABLE_MSVC_WARNING(4512)                                     \
+                                                                                \
     template <typename boost_fusion_detail_Seq, int N>                          \
     struct BOOST_FUSION_ITERATOR_NAME(NAME)                                     \
         : boost::fusion::iterator_facade<                                       \
@@ -418,7 +421,10 @@
                 return type(it.seq_);                                           \
             }                                                                   \
         };                                                                      \
-    };
+    };                                                                          \
+                                                                                \
+    BOOST_FUSION_POP_WARNINGS                                                   \
+    /**/
 
 
 #define BOOST_FUSION_DEFINE_STRUCT_INLINE_MEMBERS_IMPL_IMPL(                    \

--- a/include/boost/fusion/adapted/struct/detail/proxy_type.hpp
+++ b/include/boost/fusion/adapted/struct/detail/proxy_type.hpp
@@ -19,6 +19,9 @@
                                                                                 \
     BOOST_FUSION_ADAPT_STRUCT_NAMESPACE_DEFINITION_BEGIN(NAMESPACE_SEQ)         \
                                                                                 \
+    BOOST_FUSION_PUSH_WARNINGS                                                  \
+    BOOST_FUSION_DISABLE_MSVC_WARNING(4512)                                     \
+                                                                                \
     struct NAME                                                                 \
     {                                                                           \
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                                \
@@ -27,9 +30,9 @@
         {}                                                                      \
                                                                                 \
         WRAPPED_TYPE& obj;                                                      \
-                                                                                \
-        BOOST_DELETED_FUNCTION(NAME& operator= (NAME const&))                   \
     };                                                                          \
+                                                                                \
+    BOOST_FUSION_POP_WARNINGS                                                   \
                                                                                 \
     BOOST_FUSION_ADAPT_STRUCT_NAMESPACE_DEFINITION_END(NAMESPACE_SEQ)
 

--- a/include/boost/fusion/algorithm/iteration/detail/segmented_fold.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/segmented_fold.hpp
@@ -14,6 +14,10 @@
 
 namespace boost { namespace fusion { namespace detail
 {
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
     template <typename Fun>
     struct segmented_fold_fun
     {
@@ -37,6 +41,9 @@ namespace boost { namespace fusion { namespace detail
             }
         };
     };
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
     // The default implementation of this lives in detail/fold.hpp
     template <typename Sequence, typename State, typename Fun, bool IsSequence, bool IsSegmented>

--- a/include/boost/fusion/algorithm/iteration/detail/segmented_for_each.hpp
+++ b/include/boost/fusion/algorithm/iteration/detail/segmented_for_each.hpp
@@ -13,6 +13,11 @@
 #include <boost/fusion/algorithm/iteration/for_each_fwd.hpp>
 #include <boost/fusion/support/segmented_fold_until.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion { namespace detail
 {
     template <typename Fun>
@@ -48,5 +53,9 @@ namespace boost { namespace fusion { namespace detail
         fusion::segmented_fold_until(seq, void_(), segmented_for_each_fun<F>(f));
     }
 }}}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/fusion/algorithm/transformation/pop_back.hpp
+++ b/include/boost/fusion/algorithm/transformation/pop_back.hpp
@@ -18,6 +18,11 @@
 #include <boost/mpl/int.hpp>
 #include <boost/mpl/if.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     template <typename Iterator_, bool IsLast>
@@ -167,6 +172,10 @@ namespace boost { namespace fusion
         );
     }
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif
 

--- a/include/boost/fusion/container/deque/deque_iterator.hpp
+++ b/include/boost/fusion/container/deque/deque_iterator.hpp
@@ -20,6 +20,11 @@
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_reference.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion {
 
     struct bidirectional_traversal_tag;
@@ -110,12 +115,13 @@ namespace boost { namespace fusion {
         {};
 
         Seq& seq_;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(deque_iterator& operator= (deque_iterator const&))
     };
 
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/container/list/cons_iterator.hpp
+++ b/include/boost/fusion/container/list/cons_iterator.hpp
@@ -26,6 +26,10 @@ namespace boost { namespace fusion
     template <typename Cons>
     struct cons_iterator_identity;
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
     template <typename Cons = nil_>
     struct cons_iterator : iterator_base<cons_iterator<Cons> >
     {
@@ -41,10 +45,10 @@ namespace boost { namespace fusion
             : cons(in_cons) {}
 
         cons_type& cons;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(cons_iterator& operator= (cons_iterator const&))
     };
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
     struct nil_iterator : iterator_base<nil_iterator>
     {

--- a/include/boost/fusion/container/map/map_iterator.hpp
+++ b/include/boost/fusion/container/map/map_iterator.hpp
@@ -17,6 +17,11 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/add_const.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct random_access_traversal_tag;
@@ -155,12 +160,12 @@ namespace boost { namespace fusion
         {};
 
         Seq& seq_;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(map_iterator& operator= (map_iterator const&))
     };
-
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/container/vector/vector_iterator.hpp
+++ b/include/boost/fusion/container/vector/vector_iterator.hpp
@@ -19,6 +19,11 @@
 #include <boost/type_traits/add_const.hpp>
 #include <boost/mpl/int.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct vector_iterator_tag;
@@ -41,16 +46,13 @@ namespace boost { namespace fusion
         vector_iterator(Vector& in_vec)
             : vec(in_vec) {}
 
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        vector_iterator(vector_iterator const& rhs)
-            : vec(rhs.vec) {}
-
         Vector& vec;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(vector_iterator& operator= (vector_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/iterator/detail/segment_sequence.hpp
+++ b/include/boost/fusion/iterator/detail/segment_sequence.hpp
@@ -13,6 +13,11 @@
 #include <boost/fusion/support/tag_of.hpp>
 #include <boost/fusion/sequence/intrinsic_fwd.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion { namespace detail
 {
     struct segment_sequence_tag {};
@@ -35,6 +40,10 @@ namespace boost { namespace fusion { namespace detail
         {}
     };
 }
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 namespace extension
 {

--- a/include/boost/fusion/iterator/iterator_adapter.hpp
+++ b/include/boost/fusion/iterator/iterator_adapter.hpp
@@ -19,6 +19,11 @@
 #include <boost/fusion/iterator/value_of.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     template <typename Derived_, typename Iterator_,
@@ -134,6 +139,10 @@ namespace boost { namespace fusion
         };
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/sequence/io/detail/manip.hpp
+++ b/include/boost/fusion/sequence/io/detail/manip.hpp
@@ -75,6 +75,10 @@ namespace boost { namespace fusion
             }
         };
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
         template <typename Tag, typename Stream>
         class string_ios_manip
         {
@@ -143,10 +147,10 @@ namespace boost { namespace fusion
             }
 
             Stream& stream;
-
-            // silence MSVC warning C4512: assignment operator could not be generated
-            BOOST_DELETED_FUNCTION(string_ios_manip& operator= (string_ios_manip const&))
         };
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
     } // detail
 

--- a/include/boost/fusion/support/config.hpp
+++ b/include/boost/fusion/support/config.hpp
@@ -127,4 +127,14 @@ namespace boost { namespace fusion { namespace detail
 #   define BOOST_FUSION_NOEXCEPT_ON_DEFAULTED BOOST_NOEXCEPT
 #endif
 
+#ifdef _MSC_VER
+#   define BOOST_FUSION_PUSH_WARNINGS __pragma(warning(push))
+#   define BOOST_FUSION_POP_WARNINGS  __pragma(warning(pop))
+#   define BOOST_FUSION_DISABLE_MSVC_WARNING(num) __pragma(warning(disable : num))
+#else
+#   define BOOST_FUSION_PUSH_WARNINGS
+#   define BOOST_FUSION_POP_WARNINGS
+#   define BOOST_FUSION_DISABLE_MSVC_WARNING(num)
+#endif
+
 #endif

--- a/include/boost/fusion/view/filter_view/filter_view.hpp
+++ b/include/boost/fusion/view/filter_view/filter_view.hpp
@@ -22,6 +22,11 @@
 #include <boost/mpl/inherit.hpp>
 #include <boost/mpl/identity.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct filter_view_tag;
@@ -52,20 +57,16 @@ namespace boost { namespace fusion
         {}
 
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        filter_view(filter_view const& rhs)
-            : seq(rhs.seq)
-        {}
-
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         first_type first() const { return fusion::begin(seq); }
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         last_type last() const { return fusion::end(seq); }
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(filter_view& operator= (filter_view const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif
 

--- a/include/boost/fusion/view/filter_view/filter_view_iterator.hpp
+++ b/include/boost/fusion/view/filter_view/filter_view_iterator.hpp
@@ -26,6 +26,11 @@
 #include <boost/fusion/view/filter_view/detail/value_of_data_impl.hpp>
 #include <boost/fusion/view/filter_view/detail/key_of_impl.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct filter_view_iterator_tag;
@@ -59,16 +64,13 @@ namespace boost { namespace fusion
         filter_iterator(First const& in_first)
             : first(filter::iter_call(first_converter::call(in_first))) {}
 
-        BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
-        filter_iterator(filter_iterator const& rhs)
-            : first(rhs.first) {}
-
         first_type first;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(filter_iterator& operator= (filter_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/view/flatten_view/flatten_view.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view.hpp
@@ -19,6 +19,10 @@
 #include <boost/fusion/sequence/intrinsic/end.hpp>
 #include <boost/fusion/view/flatten_view/flatten_view_iterator.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
 
 namespace boost { namespace fusion
 {
@@ -51,6 +55,10 @@ namespace boost { namespace fusion
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 namespace boost { namespace fusion { namespace extension
 {

--- a/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
+++ b/include/boost/fusion/view/flatten_view/flatten_view_iterator.hpp
@@ -19,6 +19,10 @@
 #include <boost/fusion/iterator/deref.hpp>
 #include <boost/fusion/iterator/value_of.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
 
 namespace boost { namespace fusion
 {
@@ -45,6 +49,10 @@ namespace boost { namespace fusion
         base_type base;
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 namespace boost { namespace fusion { namespace detail
 {

--- a/include/boost/fusion/view/identity_view/identity_view.hpp
+++ b/include/boost/fusion/view/identity_view/identity_view.hpp
@@ -28,6 +28,10 @@ namespace boost {
     };
 }
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
 namespace boost { namespace fusion {
     template<typename Sequence> struct identity_view 
         : transform_view<Sequence, detail::identity>
@@ -39,5 +43,8 @@ namespace boost { namespace fusion {
             : base_type(in_seq, detail::identity()) {}
     };
 }}
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif 

--- a/include/boost/fusion/view/joint_view/joint_view.hpp
+++ b/include/boost/fusion/view/joint_view/joint_view.hpp
@@ -25,6 +25,11 @@
 #include <boost/mpl/inherit.hpp>
 #include <boost/mpl/identity.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct joint_view_tag;
@@ -69,14 +74,15 @@ namespace boost { namespace fusion
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         concat_last_type concat_last() const { return fusion::end(seq2); }
 
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(joint_view& operator= (joint_view const&))
-
     private:
         typename mpl::if_<traits::is_view<Sequence1>, Sequence1, Sequence1&>::type seq1;
         typename mpl::if_<traits::is_view<Sequence2>, Sequence2, Sequence2&>::type seq2;
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif
 

--- a/include/boost/fusion/view/joint_view/joint_view_iterator.hpp
+++ b/include/boost/fusion/view/joint_view/joint_view_iterator.hpp
@@ -20,6 +20,11 @@
 #include <boost/fusion/view/joint_view/detail/key_of_impl.hpp>
 #include <boost/static_assert.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct joint_view_iterator_tag;
@@ -49,11 +54,12 @@ namespace boost { namespace fusion
 
         first_type first;
         concat_type concat;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(joint_view_iterator& operator= (joint_view_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/view/nview/nview_iterator.hpp
+++ b/include/boost/fusion/view/nview/nview_iterator.hpp
@@ -26,6 +26,11 @@
 #include <boost/fusion/view/nview/detail/distance_impl.hpp>
 #include <boost/fusion/view/nview/detail/equal_to_impl.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct nview_iterator_tag;
@@ -46,12 +51,13 @@ namespace boost { namespace fusion
           : seq(in_seq) {}
 
         Sequence& seq;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(nview_iterator& operator= (nview_iterator const&))
     };
 
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/view/repetitive_view/repetitive_view.hpp
+++ b/include/boost/fusion/view/repetitive_view/repetitive_view.hpp
@@ -18,6 +18,10 @@
 #include <boost/fusion/view/repetitive_view/detail/begin_impl.hpp>
 #include <boost/fusion/view/repetitive_view/detail/end_impl.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
 
 namespace boost { namespace fusion
 {
@@ -43,11 +47,12 @@ namespace boost { namespace fusion
             : seq(in_seq) {}
 
         stored_seq_type seq;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(repetitive_view& operator= (repetitive_view const&))
     };
 
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif

--- a/include/boost/fusion/view/repetitive_view/repetitive_view_iterator.hpp
+++ b/include/boost/fusion/view/repetitive_view/repetitive_view_iterator.hpp
@@ -19,6 +19,11 @@
 #include <boost/fusion/view/repetitive_view/detail/next_impl.hpp>
 #include <boost/fusion/view/repetitive_view/detail/value_of_impl.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct repetitive_view_iterator_tag;
@@ -46,11 +51,12 @@ namespace boost { namespace fusion
 
         Sequence& seq;
         pos_type pos;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(repetitive_view_iterator& operator= (repetitive_view_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/view/reverse_view/reverse_view.hpp
+++ b/include/boost/fusion/view/reverse_view/reverse_view.hpp
@@ -27,6 +27,11 @@
 #include <boost/mpl/inherit.hpp>
 #include <boost/mpl/identity.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct reverse_view_tag;
@@ -60,11 +65,12 @@ namespace boost { namespace fusion
         BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
         last_type last() const { return fusion::end(seq); }
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(reverse_view& operator= (reverse_view const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif
 

--- a/include/boost/fusion/view/reverse_view/reverse_view_iterator.hpp
+++ b/include/boost/fusion/view/reverse_view/reverse_view_iterator.hpp
@@ -24,6 +24,11 @@
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/static_assert.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct reverse_view_iterator_tag;
@@ -47,11 +52,12 @@ namespace boost { namespace fusion
             : first(converter::call(in_first)) {}
 
         first_type first;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(reverse_view_iterator& operator= (reverse_view_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/view/single_view/single_view_iterator.hpp
+++ b/include/boost/fusion/view/single_view/single_view_iterator.hpp
@@ -20,6 +20,11 @@
 #include <boost/fusion/view/single_view/detail/value_of_impl.hpp>
 #include <boost/config.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct single_view_iterator_tag;
@@ -40,10 +45,12 @@ namespace boost { namespace fusion
             : view(in_view) {}
 
         SingleView& view;
-
-        BOOST_DELETED_FUNCTION(single_view_iterator& operator=(single_view_iterator const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/include/boost/fusion/view/transform_view/detail/deref_data_impl.hpp
+++ b/include/boost/fusion/view/transform_view/detail/deref_data_impl.hpp
@@ -10,6 +10,11 @@
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/iterator/deref.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/type_traits/add_const.hpp>
+#include <boost/type_traits/add_reference.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_reference.hpp>
+#include <boost/utility/result_of.hpp>
 
 namespace boost { namespace fusion
 {

--- a/include/boost/fusion/view/transform_view/transform_view.hpp
+++ b/include/boost/fusion/view/transform_view/transform_view.hpp
@@ -27,6 +27,11 @@
 #include <boost/fusion/sequence/intrinsic/size.hpp>
 #include <boost/mpl/bool.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     struct void_;
@@ -75,9 +80,6 @@ namespace boost { namespace fusion
         transform_type f;
         typename mpl::if_<traits::is_view<Sequence1>, Sequence1, Sequence1&>::type seq1;
         typename mpl::if_<traits::is_view<Sequence2>, Sequence2, Sequence2&>::type seq2;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(transform_view& operator= (transform_view const&))
     };
 
     // Unary Version
@@ -111,11 +113,12 @@ namespace boost { namespace fusion
         last_type last() const { return fusion::end(seq); }
         typename mpl::if_<traits::is_view<Sequence>, Sequence, Sequence&>::type seq;
         transform_type f;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(transform_view& operator= (transform_view const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif
 

--- a/include/boost/fusion/view/transform_view/transform_view_iterator.hpp
+++ b/include/boost/fusion/view/transform_view/transform_view_iterator.hpp
@@ -23,6 +23,11 @@
 #include <boost/fusion/view/transform_view/detail/value_of_data_impl.hpp>
 #include <boost/fusion/view/transform_view/detail/deref_data_impl.hpp>
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
+
 namespace boost { namespace fusion
 {
     // Unary Version
@@ -44,9 +49,6 @@ namespace boost { namespace fusion
 
         first_type first;
         transform_type f;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(transform_view_iterator& operator= (transform_view_iterator const&))
     };
 
     // Binary Version
@@ -71,11 +73,12 @@ namespace boost { namespace fusion
         first1_type first1;
         first2_type first2;
         transform_type f;
-
-        // silence MSVC warning C4512: assignment operator could not be generated
-        BOOST_DELETED_FUNCTION(transform_view_iterator2& operator= (transform_view_iterator2 const&))
     };
 }}
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #ifdef BOOST_FUSION_WORKAROUND_FOR_LWG_2408
 namespace std

--- a/test/sequence/segmented_iterator_range.cpp
+++ b/test/sequence/segmented_iterator_range.cpp
@@ -21,6 +21,10 @@
 #include <boost/static_assert.hpp>
 #include "tree.hpp"
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable: 4512) // assignment operator could not be generated.
+#endif
 struct ostream_fun
 {
     ostream_fun(std::ostream &sout)
@@ -34,6 +38,9 @@ struct ostream_fun
 private:
     std::ostream & sout_;
 };
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 template<typename Tree>
 void


### PR DESCRIPTION
Clang 13 have new warning under the same group