### PR TITLE
Add describe dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,7 @@ jobs:
           git submodule init libs/type_traits
           git submodule init libs/typeof
           git submodule init libs/utility
+          git submodule init libs/describe
           git submodule init libs/headers tools/boost_install tools/build
           git submodule update
           rm -rf libs/fusion
@@ -452,6 +453,7 @@ jobs:
           git submodule init libs/type_traits
           git submodule init libs/typeof
           git submodule init libs/utility
+          git submodule init libs/describe
           git submodule init libs/headers tools/boost_install tools/build
           git submodule update
           rm -rf libs/fusion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,7 @@ jobs:
           git submodule init libs/typeof
           git submodule init libs/utility
           git submodule init libs/describe
+          git submodule init libs/mp11
           git submodule init libs/headers tools/boost_install tools/build
           git submodule update
           rm -rf libs/fusion
@@ -454,6 +455,7 @@ jobs:
           git submodule init libs/typeof
           git submodule init libs/utility
           git submodule init libs/describe
+          git submodule init libs/mp11
           git submodule init libs/headers tools/boost_install tools/build
           git submodule update
           rm -rf libs/fusion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,5 @@ target_link_libraries(boost_fusion
         Boost::typeof
         Boost::utility
         Boost::functional
+        Boost::describe
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,4 +25,5 @@ target_link_libraries(boost_fusion
         Boost::utility
         Boost::functional
         Boost::describe
+        Boost::mp11
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,6 +82,7 @@ install:
   - git submodule init libs/type_traits
   - git submodule init libs/typeof
   - git submodule init libs/utility
+  - git submodule init libs/describe
 
   - git submodule init libs/headers tools/boost_install tools/build
   - git submodule update

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,6 +83,7 @@ install:
   - git submodule init libs/typeof
   - git submodule init libs/utility
   - git submodule init libs/describe
+  - git submodule init libs/mp11
 
   - git submodule init libs/headers tools/boost_install tools/build
   - git submodule update


### PR DESCRIPTION
Just to fix Appveyor-side compilation error:
```
.\boost/container_hash/is_described_class.hpp(10,10): fatal error: 'boost/describe/bases.hpp' file not found
#include <boost/describe/bases.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```