### PR TITLE
Implemented ability to set fallback for tag_of

### DIFF
--- a/include/boost/fusion/support/tag_of.hpp
+++ b/include/boost/fusion/support/tag_of.hpp
@@ -48,11 +48,17 @@ namespace boost { namespace fusion
     {
         BOOST_MPL_HAS_XXX_TRAIT_DEF(fusion_tag)
 
+        template<typename Sequence, typename Active=void>
+        struct tag_of_fallback
+        {
+            typedef non_fusion_tag type;
+        };
+
         template <typename Sequence, typename Active>
         struct tag_of_impl
           : mpl::if_<fusion::detail::is_mpl_sequence<Sequence>,
               mpl::identity<mpl_sequence_tag>,
-              mpl::identity<non_fusion_tag> >::type
+              mpl::identity<typename tag_of_fallback<Sequence>::type> >::type
         {};
 
         template <typename Sequence>

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -271,6 +271,7 @@ project
         : [ requires cxx11_variadic_templates ] ]
     [ compile support/tag_of.cpp ]
     [ compile support/unused.cpp ]
+    [ compile support/detail/tag_of_fallback.cpp ]
 
 #   [ compile-fail xxx.cpp  ]
 

--- a/test/support/detail/tag_of_fallback.cpp
+++ b/test/support/detail/tag_of_fallback.cpp
@@ -1,0 +1,50 @@
+/*=============================================================================
+    Copyright (c) 2022 Denis Mikhailov
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/fusion/support/tag_of.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace mpl = boost::mpl;
+
+template<typename T>
+struct my_is_implicitly_reflectable;
+
+namespace boost { namespace fusion
+{
+    struct boost_my_reflectable_tag;
+    namespace detail
+    {
+        template<typename Sequence>
+        struct tag_of_fallback<Sequence, typename boost::enable_if<boost::is_same<Sequence, Sequence> >::type>
+        {
+            typedef typename mpl::if_<my_is_implicitly_reflectable<Sequence>
+                         , boost_my_reflectable_tag
+                         , non_fusion_tag
+            >::type type;
+        };
+    }
+}}
+
+struct reflectable {};
+struct non_reflectable {};
+
+template<typename T>
+struct my_is_implicitly_reflectable : mpl::false_ {};
+template<>
+struct my_is_implicitly_reflectable<reflectable> : mpl::true_ {};
+
+typedef boost::fusion::traits::tag_of<reflectable>::type ReflectableTag;
+typedef boost::fusion::traits::tag_of<non_reflectable>::type NonReflectableTag;
+BOOST_STATIC_ASSERT((boost::is_same<ReflectableTag, boost::fusion::boost_my_reflectable_tag>::value));
+BOOST_STATIC_ASSERT((boost::is_same<NonReflectableTag, boost::fusion::non_fusion_tag>::value));
+
+int
+main() { }
+


### PR DESCRIPTION
Needs for https://github.com/boostorg/fusion/issues/231.
It will allow to integrate PFR implicitly as fallback, so thus PFR will be selected when no other reflection not found for T.