### PR TITLE
missing make_pair() for r-value refs

### DIFF
--- a/include/boost/fusion/support/pair.hpp
+++ b/include/boost/fusion/support/pair.hpp
@@ -121,6 +121,15 @@ namespace boost { namespace fusion
     }
 
     template <typename First, typename Second>
+    BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
+    inline typename result_of::make_pair<First,Second>::type
+    make_pair(Second&& val)
+    {
+        return pair<First, typename detail::as_fusion_element<Second>::type>(
+            BOOST_FUSION_FWD_ELEM(Second, val));
+    }
+
+    template <typename First, typename Second>
     inline std::ostream&
     operator<<(std::ostream& os, pair<First, Second> const& p)
     {

--- a/include/boost/fusion/support/pair.hpp
+++ b/include/boost/fusion/support/pair.hpp
@@ -120,6 +120,7 @@ namespace boost { namespace fusion
         return pair<First, typename detail::as_fusion_element<Second>::type>(val);
     }
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     template <typename First, typename Second>
     BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED
     inline typename result_of::make_pair<First,Second>::type
@@ -128,6 +129,7 @@ namespace boost { namespace fusion
         return pair<First, typename detail::as_fusion_element<Second>::type>(
             BOOST_FUSION_FWD_ELEM(Second, val));
     }
+#endif
 
     template <typename First, typename Second>
     inline std::ostream&

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -272,7 +272,7 @@ project
     [ compile support/tag_of.cpp ]
     [ compile support/unused.cpp ]
 
-    [ compile support/make_pair_r-value.cpp : :
+    [ compile support/make_pair_r-value.cpp
         : [ requires cxx11_rvalue_references ] ]
 
 #   [ compile-fail xxx.cpp  ]

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -272,7 +272,8 @@ project
     [ compile support/tag_of.cpp ]
     [ compile support/unused.cpp ]
 
-    [ compile support/make_pair_r-value.cpp ]
+    [ compile support/make_pair_r-value.cpp : :
+        : [ requires cxx11_rvalue_references ] ]
 
 #   [ compile-fail xxx.cpp  ]
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -272,6 +272,8 @@ project
     [ compile support/tag_of.cpp ]
     [ compile support/unused.cpp ]
 
+    [ compile support/make_pair_r-value.cpp ]
+
 #   [ compile-fail xxx.cpp  ]
 
     ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -272,6 +272,7 @@ project
     [ compile support/tag_of.cpp ]
     [ compile support/unused.cpp ]
 
+    [ compile-fail support/make_pair_r-value.cpp ]
     [ compile support/make_pair_r-value.cpp
         : [ requires cxx11_rvalue_references ] ]
 

--- a/test/support/make_pair_r-value.cpp
+++ b/test/support/make_pair_r-value.cpp
@@ -9,9 +9,10 @@
 struct noncopyable_type {
     noncopyable_type(const noncopyable_type &) = delete;
     noncopyable_type& operator=(const noncopyable_type &) = delete;
-    
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     noncopyable_type(noncopyable_type &&) = default;
     noncopyable_type& operaotr=(noncopyable_type &&) = default;
+#endif
 };
 
 int main() {
@@ -19,5 +20,5 @@ int main() {
 
     pair<int, noncopyable_type> val = make_pair<int>(noncopyable_type{});
 
-	return 0;
+    return 0;
 }

--- a/test/support/make_pair_r-value.cpp
+++ b/test/support/make_pair_r-value.cpp
@@ -9,7 +9,9 @@
 struct noncopyable_type {
     noncopyable_type(const noncopyable_type &) = delete;
     noncopyable_type& operator=(const noncopyable_type &) = delete;
-
+    
+    noncopyable_type(noncopyable_type &&) = default;
+    noncopyable_type& operaotr=(noncopyable_type &&) = default;
 };
 
 int main() {

--- a/test/support/make_pair_r-value.cpp
+++ b/test/support/make_pair_r-value.cpp
@@ -1,0 +1,21 @@
+/*=============================================================================
+    Copyright (c) 2022 niXman (github dot nixman at pm.me)
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#include <boost/fusion/support/pair.hpp>
+
+struct noncopyable_type {
+    noncopyable_type(const noncopyable_type &) = delete;
+    noncopyable_type& operator=(const noncopyable_type &) = delete;
+
+};
+
+int main() {
+    using namespace boost::fusion;
+
+    pair<int, noncopyable_type> val = make_pair<int>(noncopyable_type{});
+
+	return 0;
+}


### PR DESCRIPTION
hello guys!

the `make_pair()` for r-value refs is required for r-value, otherwise `non-copyable` but `movable` can't be constructed.


thanks!