### PR TITLE
Remove template arguments redefinition workaround for VS2022 update 5

### DIFF
--- a/include/boost/fusion/adapted/struct/detail/adapt_base.hpp
+++ b/include/boost/fusion/adapted/struct/detail/adapt_base.hpp
@@ -143,7 +143,7 @@
         I,                                                                      \
         ATTRIBUTE)
 
-#ifdef BOOST_MSVC
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1935)
 #   define BOOST_FUSION_ADAPT_STRUCT_MSVC_REDEFINE_TEMPLATE_PARAM(R,_,ELEM)     \
         typedef ELEM ELEM;
 #   define BOOST_FUSION_ADAPT_STRUCT_MSVC_REDEFINE_TEMPLATE_PARAMS_IMPL(SEQ)    \


### PR DESCRIPTION
Update 5 adds `/Zc:templateScope` flag which causes compile errors in typedefs redefining template parameters.

This fixes compilation errors of Boost.Log that were reported on boost-dev ML.
