### PR TITLE
Don't include std stream headers ourselves

### DIFF
--- a/include/boost/fusion/sequence/io/detail/in.hpp
+++ b/include/boost/fusion/sequence/io/detail/in.hpp
@@ -10,7 +10,6 @@
 #define FUSION_IN_05052005_0121
 
 #include <boost/fusion/support/config.hpp>
-#include <istream>
 #include <boost/fusion/sequence/io/detail/manip.hpp>
 
 #include <boost/mpl/bool.hpp>

--- a/include/boost/fusion/sequence/io/detail/manip.hpp
+++ b/include/boost/fusion/sequence/io/detail/manip.hpp
@@ -36,10 +36,10 @@ namespace boost { namespace fusion
     namespace detail
     {
         template <typename Tag>
-        int get_xalloc_index(Tag* = 0)
+        int get_xalloc_index(int xalloc())
         {
             // each Tag will have a unique index
-            static int index = std::ios::xalloc();
+            static int const index = xalloc();
             return index;
         }
 
@@ -66,12 +66,12 @@ namespace boost { namespace fusion
             {
                 static arena ar; // our arena
                 ar.data.push_back(new T(data));
-                stream.pword(get_xalloc_index<Tag>()) = ar.data.back();
+                stream.pword(get_xalloc_index<Tag>(stream.xalloc)) = ar.data.back();
             }
 
             static T const* get(Stream& stream)
             {
-                return (T const*)stream.pword(get_xalloc_index<Tag>());
+                return (T const*)stream.pword(get_xalloc_index<Tag>(stream.xalloc));
             }
         };
 
@@ -114,7 +114,6 @@ namespace boost { namespace fusion
             {
                 // read a delimiter
                 string_type const* p = stream_data_t::get(stream);
-                std::ws(stream);
 
                 if (p)
                 {
@@ -141,7 +140,7 @@ namespace boost { namespace fusion
                     if (stream.get() != c)
                     {
                         stream.unget();
-                        stream.setstate(std::ios::failbit);
+                        stream.setstate(Stream::failbit);
                     }
                 }
             }

--- a/include/boost/fusion/sequence/io/detail/out.hpp
+++ b/include/boost/fusion/sequence/io/detail/out.hpp
@@ -10,7 +10,6 @@
 #define FUSION_OUT_05052005_0121
 
 #include <boost/fusion/support/config.hpp>
-#include <ostream>
 #include <boost/fusion/sequence/io/detail/manip.hpp>
 
 #include <boost/mpl/bool.hpp>

--- a/include/boost/fusion/sequence/io/in.hpp
+++ b/include/boost/fusion/sequence/io/in.hpp
@@ -10,9 +10,9 @@
 #define BOOST_IN_05042005_0120
 
 #include <boost/fusion/support/config.hpp>
-#include <istream>
 #include <boost/fusion/sequence/io/detail/in.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
+#include <iosfwd>
 
 namespace boost { namespace fusion
 {

--- a/include/boost/fusion/sequence/io/out.hpp
+++ b/include/boost/fusion/sequence/io/out.hpp
@@ -10,11 +10,11 @@
 #define BOOST_OUT_05042005_0120
 
 #include <boost/fusion/support/config.hpp>
-#include <ostream>
 #include <boost/fusion/sequence/io/detail/out.hpp>
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/mpl/or.hpp>
+#include <iosfwd>
 
 namespace boost { namespace fusion
 {


### PR DESCRIPTION
Saves compile time when these things are not actually used.