### PR TITLE
Fix include guard in `adapt_assoc_adt.hpp`

### DIFF
--- a/include/boost/fusion/include/adapt_assoc_adt.hpp
+++ b/include/boost/fusion/include/adapt_assoc_adt.hpp
@@ -6,7 +6,7 @@
 ==============================================================================*/
 
 #ifndef BOOST_FUSION_INCLUDE_ADAPT_ASSOC_ADT_HPP
-#define BOOST_FUSION_INCLUDE_ADAPT_ASSOC_ADR_HPP
+#define BOOST_FUSION_INCLUDE_ADAPT_ASSOC_ADT_HPP
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/adapted/adt/adapt_assoc_adt.hpp>


### PR DESCRIPTION
This is relatively minor because the header just includes two others, but this is triggering some internal tooling of ours and should be fixed.