### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,27 +5,30 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/container_hash//boost_container_hash
+    /boost/core//boost_core
+    /boost/function_types//boost_function_types
+    /boost/functional//boost_functional
+    /boost/mpl//boost_mpl
+    /boost/preprocessor//boost_preprocessor
+    /boost/static_assert//boost_static_assert
+    /boost/tuple//boost_tuple
+    /boost/type_traits//boost_type_traits
+    /boost/typeof//boost_typeof
+    /boost/utility//boost_utility ;
+
 project /boost/fusion
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/container_hash//boost_container_hash
-        <library>/boost/core//boost_core
-        <library>/boost/function_types//boost_function_types
-        <library>/boost/functional//boost_functional
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/tuple//boost_tuple
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/typeof//boost_typeof
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_fusion ]
+    [ alias boost_fusion : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_fusion test ]
     ;
 
 call-if : boost-library fusion
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,31 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/fusion
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/container_hash//boost_container_hash
+        <source>/boost/core//boost_core
+        <source>/boost/function_types//boost_function_types
+        <source>/boost/functional//boost_functional
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/tuple//boost_tuple
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/typeof//boost_typeof
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_fusion ]
+    [ alias all : boost_fusion test ]
+    ;
+
+call-if : boost-library fusion
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/fusion
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/fusion

--- a/build.jam
+++ b/build.jam
@@ -7,18 +7,18 @@ import project ;
 
 project /boost/fusion
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/container_hash//boost_container_hash
-        <source>/boost/core//boost_core
-        <source>/boost/function_types//boost_function_types
-        <source>/boost/functional//boost_functional
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/tuple//boost_tuple
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/typeof//boost_typeof
-        <source>/boost/utility//boost_utility
+        <library>/boost/config//boost_config
+        <library>/boost/container_hash//boost_container_hash
+        <library>/boost/core//boost_core
+        <library>/boost/function_types//boost_function_types
+        <library>/boost/functional//boost_functional
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/tuple//boost_tuple
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/typeof//boost_typeof
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -26,8 +26,8 @@ project
 {
     test-suite fusion :
 
-    [ run algorithm/all.cpp : : : <source>/boost/lambda//boost_lambda ]
-    [ run algorithm/any.cpp : : : <source>/boost/lambda//boost_lambda ]
+    [ run algorithm/all.cpp : : : <library>/boost/lambda//boost_lambda ]
+    [ run algorithm/any.cpp : : : <library>/boost/lambda//boost_lambda ]
     [ run algorithm/clear.cpp ]
     [ run algorithm/copy.cpp ]
     [ run algorithm/count.cpp ]
@@ -45,8 +45,8 @@ project
     [ run algorithm/iter_fold.cpp ]
     [ run algorithm/move.cpp : :
         : [ requires cxx11_rvalue_references ] ]
-    [ run algorithm/none.cpp : : : <source>/boost/lambda//boost_lambda ]
-    [ run algorithm/pop_back.cpp : : : <source>/boost/array//boost_array ]
+    [ run algorithm/none.cpp : : : <library>/boost/lambda//boost_lambda ]
+    [ run algorithm/pop_back.cpp : : : <library>/boost/array//boost_array ]
     [ run algorithm/pop_front.cpp ]
     [ run algorithm/push_back.cpp ]
     [ run algorithm/push_front.cpp ]
@@ -77,7 +77,7 @@ project
     [ run sequence/as_vector.cpp ]
     [ run sequence/boost_tuple.cpp ]
     [ run sequence/boost_tuple_iterator.cpp ]
-    [ run sequence/cons.cpp : : : <source>/boost/lambda//boost_lambda ]
+    [ run sequence/cons.cpp : : : <library>/boost/lambda//boost_lambda ]
     [ run sequence/convert_boost_tuple.cpp ]
     [ run sequence/convert_deque.cpp ]
     [ run sequence/convert_list.cpp ]
@@ -135,7 +135,7 @@ project
     [ run sequence/set.cpp ]
     [ run sequence/single_view.cpp ]
     [ run sequence/std_pair.cpp ]
-    [ run sequence/boost_array.cpp : : : <source>/boost/array//boost_array ]
+    [ run sequence/boost_array.cpp : : : <library>/boost/array//boost_array ]
     [ run sequence/array.cpp ]
     [ run sequence/std_array.cpp : :
         : [ requires cxx11_hdr_array ] ]
@@ -242,7 +242,7 @@ project
     [ compile sequence/github-159.cpp ]
     [ run sequence/github-176.cpp ]
 
-    [ compile sequence/size.cpp : <source>/boost/array//boost_array ]
+    [ compile sequence/size.cpp : <library>/boost/array//boost_array ]
 
     [ run functional/fused.cpp ]
     [ run functional/fused_function_object.cpp ]

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,6 +10,7 @@
 # bring in rules for testing
 import testing ;
 import os ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 if [ os.environ CI ]

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -20,6 +20,7 @@ if [ os.environ CI ]
 
 project
     : requirements
+        <library>/boost/fusion//boost_fusion
         $(CI_DEFINES)
     ;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,7 +10,7 @@
 # bring in rules for testing
 import testing ;
 import os ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 if [ os.environ CI ]
 {
@@ -25,8 +25,8 @@ project
 {
     test-suite fusion :
 
-    [ run algorithm/all.cpp ]
-    [ run algorithm/any.cpp ]
+    [ run algorithm/all.cpp : : : <source>/boost/lambda//boost_lambda ]
+    [ run algorithm/any.cpp : : : <source>/boost/lambda//boost_lambda ]
     [ run algorithm/clear.cpp ]
     [ run algorithm/copy.cpp ]
     [ run algorithm/count.cpp ]
@@ -44,8 +44,8 @@ project
     [ run algorithm/iter_fold.cpp ]
     [ run algorithm/move.cpp : :
         : [ requires cxx11_rvalue_references ] ]
-    [ run algorithm/none.cpp ]
-    [ run algorithm/pop_back.cpp ]
+    [ run algorithm/none.cpp : : : <source>/boost/lambda//boost_lambda ]
+    [ run algorithm/pop_back.cpp : : : <source>/boost/array//boost_array ]
     [ run algorithm/pop_front.cpp ]
     [ run algorithm/push_back.cpp ]
     [ run algorithm/push_front.cpp ]
@@ -76,7 +76,7 @@ project
     [ run sequence/as_vector.cpp ]
     [ run sequence/boost_tuple.cpp ]
     [ run sequence/boost_tuple_iterator.cpp ]
-    [ run sequence/cons.cpp ]
+    [ run sequence/cons.cpp : : : <source>/boost/lambda//boost_lambda ]
     [ run sequence/convert_boost_tuple.cpp ]
     [ run sequence/convert_deque.cpp ]
     [ run sequence/convert_list.cpp ]
@@ -134,7 +134,7 @@ project
     [ run sequence/set.cpp ]
     [ run sequence/single_view.cpp ]
     [ run sequence/std_pair.cpp ]
-    [ run sequence/boost_array.cpp ]
+    [ run sequence/boost_array.cpp : : : <source>/boost/array//boost_array ]
     [ run sequence/array.cpp ]
     [ run sequence/std_array.cpp : :
         : [ requires cxx11_hdr_array ] ]
@@ -241,7 +241,7 @@ project
     [ compile sequence/github-159.cpp ]
     [ run sequence/github-176.cpp ]
 
-    [ compile sequence/size.cpp ]
+    [ compile sequence/size.cpp : <source>/boost/array//boost_array ]
 
     [ run functional/fused.cpp ]
     [ run functional/fused_function_object.cpp ]


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.