### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,6 @@ jobs:
           git submodule init libs/predef
           git submodule init libs/preprocessor
           git submodule init libs/smart_ptr
-          git submodule init libs/static_assert
           git submodule init libs/throw_exception
           git submodule init libs/tuple
           git submodule init libs/type_index
@@ -447,7 +446,6 @@ jobs:
           git submodule init libs/predef
           git submodule init libs/preprocessor
           git submodule init libs/smart_ptr
-          git submodule init libs/static_assert
           git submodule init libs/throw_exception
           git submodule init libs/tuple
           git submodule init libs/type_index

--- a/.travis.yml
+++ b/.travis.yml
@@ -229,7 +229,6 @@ install:
   - git submodule init libs/predef
   - git submodule init libs/preprocessor
   - git submodule init libs/smart_ptr
-  - git submodule init libs/static_assert
   - git submodule init libs/throw_exception
   - git submodule init libs/tuple
   - git submodule init libs/type_index

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(boost_fusion
         Boost::function_types
         Boost::mpl
         Boost::preprocessor
-        Boost::static_assert
         Boost::tuple
         Boost::type_traits
         Boost::typeof

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,6 @@ install:
   - git submodule init libs/predef
   - git submodule init libs/preprocessor
   - git submodule init libs/smart_ptr
-  - git submodule init libs/static_assert
   - git submodule init libs/throw_exception
   - git submodule init libs/tuple
   - git submodule init libs/type_index

--- a/build.jam
+++ b/build.jam
@@ -13,7 +13,6 @@ constant boost_dependencies :
     /boost/functional//boost_functional
     /boost/mpl//boost_mpl
     /boost/preprocessor//boost_preprocessor
-    /boost/static_assert//boost_static_assert
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits
     /boost/typeof//boost_typeof


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.