### PR TITLE
Use non-deprecated header include for identity.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(boost_fusion
     Boost::container_hash
     Boost::core
     Boost::function_types
-    Boost::functional
     Boost::mpl
     Boost::preprocessor
     Boost::tuple

--- a/build.jam
+++ b/build.jam
@@ -10,7 +10,6 @@ constant boost_dependencies :
     /boost/container_hash//boost_container_hash
     /boost/core//boost_core
     /boost/function_types//boost_function_types
-    /boost/functional//boost_functional
     /boost/mpl//boost_mpl
     /boost/preprocessor//boost_preprocessor
     /boost/tuple//boost_tuple
@@ -18,16 +17,12 @@ constant boost_dependencies :
     /boost/typeof//boost_typeof
     /boost/utility//boost_utility ;
 
-project /boost/fusion
-    : common-requirements
-        <include>include
-    ;
+project /boost/fusion ;
 
 explicit
-    [ alias boost_fusion : : : : <library>$(boost_dependencies) ]
+    [ alias boost_fusion : : : : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_fusion test ]
     ;
 
 call-if : boost-library fusion
     ;
-

--- a/include/boost/fusion/view/identity_view/identity_view.hpp
+++ b/include/boost/fusion/view/identity_view/identity_view.hpp
@@ -9,7 +9,7 @@
 
 #include <boost/fusion/support/config.hpp>
 #include <boost/fusion/view/transform_view.hpp>
-#include <boost/functional/identity.hpp>
+#include <boost/core/identity.hpp>
 #include <boost/utility/result_of.hpp>
 
 namespace boost { namespace fusion {


### PR DESCRIPTION
In addition to using the non-deprecated header include `boost/core/identity.hpp` instead of `boost/functional/identity.hpp`, this patch removes the only dependency of Functional, which means that Fusion will drop one level in the dependency report.